### PR TITLE
Fixed dashboard and html-report command bugs

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -36,6 +36,10 @@ func GetDashboardCommand() *cobra.Command {
 
 			var err error
 			vacuumReport, specBytes, _ := vacuum_report.BuildVacuumReportFromFile(args[0])
+			if len(specBytes) <= 0 {
+				pterm.Error.Printf("Failed to read specification: %v\n\n", args[0])
+				return err
+			}
 
 			var resultSet *model.RuleResultSet
 			var ruleset *motor.RuleSetExecutionResult
@@ -51,6 +55,7 @@ func GetDashboardCommand() *cobra.Command {
 				rulesetFlag, _ := cmd.Flags().GetString("ruleset")
 				resultSet, ruleset, err = BuildResults(rulesetFlag, specBytes, customFunctions)
 				if err != nil {
+					pterm.Error.Printf("Failed to render dashboard: %v\n\n", err)
 					return err
 				}
 				specIndex = ruleset.Index

--- a/cmd/html_report.go
+++ b/cmd/html_report.go
@@ -54,6 +54,10 @@ func GetHTMLReportCommand() *cobra.Command {
 			start := time.Now()
 			var err error
 			vacuumReport, specBytes, _ := vacuum_report.BuildVacuumReportFromFile(args[0])
+			if len(specBytes) <= 0 {
+				pterm.Error.Printf("Failed to read specification: %v\n\n", args[0])
+				return err
+			}
 
 			var resultSet *model.RuleResultSet
 			var ruleset *motor.RuleSetExecutionResult
@@ -70,10 +74,12 @@ func GetHTMLReportCommand() *cobra.Command {
 				rulesetFlag, _ := cmd.Flags().GetString("ruleset")
 				resultSet, ruleset, err = BuildResults(rulesetFlag, specBytes, customFunctions)
 				if err != nil {
+					pterm.Error.Printf("Failed to generate report: %v\n\n", err)
 					return err
 				}
 				specIndex = ruleset.Index
 				specInfo = ruleset.SpecInfo
+
 				specInfo.Generated = time.Now()
 				stats = statistics.CreateReportStatistics(specIndex, specInfo, resultSet)
 


### PR DESCRIPTION
Invalid files cause the app to crash, so this fixes that. I found this while tinkering in a pipeline.

Signed-off-by: Dave Shanley <dshanley@splunk.com>