### PR TITLE
refactor: change `plugin/sample` package to `sample`

### DIFF
--- a/plugin/sample/boot.go
+++ b/plugin/sample/boot.go
@@ -1,4 +1,4 @@
-package main
+package sample
 
 import "github.com/daveshanley/vacuum/plugin"
 

--- a/plugin/sample/boot_test.go
+++ b/plugin/sample/boot_test.go
@@ -1,4 +1,4 @@
-package main
+package sample
 
 import (
 	"github.com/daveshanley/vacuum/plugin"

--- a/plugin/sample/check_single_path.go
+++ b/plugin/sample/check_single_path.go
@@ -1,4 +1,4 @@
-package main
+package sample
 
 import (
 	"fmt"

--- a/plugin/sample/useless_func.go
+++ b/plugin/sample/useless_func.go
@@ -1,4 +1,4 @@
-package main
+package sample
 
 import (
 	"github.com/daveshanley/vacuum/model"


### PR DESCRIPTION
To make the conventional `go build ./...` and `go install ./...` work. With the sample in the `main` package currently:

```shellsession
$ go build ./...
# github.com/daveshanley/vacuum/plugin/sample
runtime.main_main·f: function main is undeclared in the main package
```

Closes https://github.com/daveshanley/vacuum/issues/135.

Warning: I didn't do any homework whatsoever with regards to vacuum plugins, so this might not be the right thing to do. If it's not, maybe it provokes another, proper fix :)