### PR TITLE
Rule updates to address issue #137 and #138

### DIFF
--- a/functions/openapi/operation_descriptions.go
+++ b/functions/openapi/operation_descriptions.go
@@ -6,6 +6,7 @@ package openapi
 import (
 	"fmt"
 	"github.com/daveshanley/vacuum/model"
+	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
 	"strconv"
@@ -56,6 +57,11 @@ func (od OperationDescription) RunRule(nodes []*yaml.Node, context model.RuleFun
 				continue
 			}
 			if strings.Contains(strings.ToLower(opMethod), "x-") {
+				skip = true
+				continue
+			}
+			// do not process parameters, they are not operations.
+			if opMethod == v3.ParametersLabel {
 				skip = true
 				continue
 			}

--- a/functions/openapi/operation_descriptions.go
+++ b/functions/openapi/operation_descriptions.go
@@ -93,7 +93,7 @@ func (od OperationDescription) RunRule(nodes []*yaml.Node, context model.RuleFun
 				descKey, descNode = utils.FindKeyNode("description", requestBodyNode.Content)
 
 				if descNode == nil {
-					res := createDescriptionResult(fmt.Sprintf("Operation `requestBody` for method `%s` at path `%s` "+
+					res := createDescriptionResult(fmt.Sprintf("Field `requestBody` for operation `%s` at path `%s` "+
 						"is missing a description", opMethod, opPath),
 						utils.BuildPath(basePath, []string{"requestBody"}), requestBodyKey, requestBodyNode)
 					res.Rule = context.Rule
@@ -104,7 +104,7 @@ func (od OperationDescription) RunRule(nodes []*yaml.Node, context model.RuleFun
 					words := strings.Split(descNode.Value, " ")
 					if len(words) < minWords {
 
-						res := createDescriptionResult(fmt.Sprintf("Operation `requestBody` for method `%s` description "+
+						res := createDescriptionResult(fmt.Sprintf("Field `requestBody` for operation `%s` description "+
 							"at path `%s` must be at least %d words long, (%d is not enough)", opMethod, opPath,
 							minWords, len(words)), basePath, descKey, descNode)
 						res.Rule = context.Rule

--- a/functions/openapi/operation_tags.go
+++ b/functions/openapi/operation_tags.go
@@ -6,6 +6,7 @@ package openapi
 import (
 	"fmt"
 	"github.com/daveshanley/vacuum/model"
+	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
 	"strings"
@@ -56,6 +57,11 @@ func (ot OperationTags) RunRule(nodes []*yaml.Node, context model.RuleFunctionCo
 					continue
 				}
 				if strings.Contains(strings.ToLower(currentVerb), "x-") {
+					skip = true
+					continue
+				}
+				// skip parameters, they are not an operation.
+				if currentVerb == v3.ParametersLabel {
 					skip = true
 					continue
 				}

--- a/functions/openapi/operation_tags_test.go
+++ b/functions/openapi/operation_tags_test.go
@@ -125,3 +125,85 @@ func TestOperationTags_RunRule_EmptyTags(t *testing.T) {
 	assert.Equal(t, "$.paths./hello.get", res[0].Path)
 
 }
+
+func TestOperationTags_RunRule_IgnoreParameters(t *testing.T) {
+
+	yml := `paths:
+  /hello:
+    post:
+      tags:
+        - a
+        - b
+    parameters:
+      - in: query`
+
+	var rootNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+	assert.NoError(t, mErr)
+
+	path := "$"
+
+	nodes, _ := utils.FindNodes([]byte(yml), path)
+
+	rule := buildOpenApiTestRuleAction(path, "operation_tags", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Index = index.NewSpecIndex(&rootNode)
+
+	def := OperationTags{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 0)
+}
+
+func TestOperationTags_RunRule_IgnoreExtensions(t *testing.T) {
+
+	yml := `paths:
+  /hello:
+    post:
+      tags:
+        - a
+        - b
+    x-parameters:
+      - in: query
+    parameters:
+      - in: path`
+
+	var rootNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+	assert.NoError(t, mErr)
+
+	path := "$"
+
+	nodes, _ := utils.FindNodes([]byte(yml), path)
+
+	rule := buildOpenApiTestRuleAction(path, "operation_tags", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Index = index.NewSpecIndex(&rootNode)
+
+	def := OperationTags{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 0)
+}
+
+func TestOperationTags_RunRule_HandleNoPaths(t *testing.T) {
+
+	yml := `openapi: 3.0.3`
+
+	var rootNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+	assert.NoError(t, mErr)
+
+	path := "$"
+
+	nodes, _ := utils.FindNodes([]byte(yml), path)
+
+	rule := buildOpenApiTestRuleAction(path, "operation_tags", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Index = index.NewSpecIndex(&rootNode)
+
+	def := OperationTags{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 0)
+}


### PR DESCRIPTION
Path global parameters were being picked up as an operation (which is not correct), added a check for params to affected rules, and then added some tests to validate they are no-longer considered an operation.

`operation_descriptions` and `operation_tags` functions were updated to address #137 

Copy updated as recommended by #138 

Closes #138 #137 