### PR TITLE
feat(pre-commit): add hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: vacuum
+  name: vacuum
+  description: OpenAPI linter and quality checker (native install)
+  language: golang
+  entry: vacuum lint
+  args: [--details]
+  files: ^(openapi|swagger)\.(json|ya?ml)$

--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ Alternatively, you can pull it from
 [Github packages](https://github.com/daveshanley/vacuum/pkgs/container/vacuum).
 To do that, replace `dshanley/vacuum` with `ghcr.io/daveshanley/vacuum` in the above commands.
 
+## Using vacuum with pre-commit
+
+Vacuum can be used with [pre-commit](https://pre-commit.com).
+
+To do that, add to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/daveshanley/vacuum
+    rev: # a tag or a commit hash from this repo, see https://github.com/daveshanley/vacuum/releases
+    hooks:
+      - id: vacuum
+```
+
+See the [hook config](./.pre-commit-hooks.yaml) here for details on what options the hook uses and what files it checks by default.
+
 ## Build an interactive HTML report 
 
 ```


### PR DESCRIPTION
This adds a native, `go install` installed [pre-commit](https://pre-commit.com) hook config.

pre-commit can do Docker images and npm installs as well. I did not add any recipe for these because
- it seems the ("immutable") tags at https://hub.docker.com/r/dshanley/vacuum/tags are not created for each release and pre-commit doesn't really work with moving tags/versions, and
- the version in package.json here is `0.0.0` and not one corresponding to the tag pre-commit clones this repo with, so the two would not be in sync.

We can return to these afterwards if the situation with them changes, but I suggest starting out with the native one here.