### PR TITLE
fix(paths): use allowlist instead of blocklist to filter operation checks

### DIFF
--- a/functions/openapi/operation_descriptions.go
+++ b/functions/openapi/operation_descriptions.go
@@ -56,12 +56,13 @@ func (od OperationDescription) RunRule(nodes []*yaml.Node, context model.RuleFun
 				opMethod = method.Value
 				continue
 			}
-			if strings.Contains(strings.ToLower(opMethod), "x-") {
-				skip = true
-				continue
-			}
-			// do not process parameters, they are not operations.
-			if opMethod == v3.ParametersLabel {
+			// skip non-operations
+			switch opMethod {
+			case
+				// No v2.*Label here, they're duplicates
+				v3.GetLabel, v3.PutLabel, v3.PostLabel, v3.DeleteLabel, v3.OptionsLabel, v3.HeadLabel, v3.PatchLabel, v3.TraceLabel:
+				// Ok, an operation
+			default:
 				skip = true
 				continue
 			}

--- a/functions/openapi/operation_descriptions_test.go
+++ b/functions/openapi/operation_descriptions_test.go
@@ -267,7 +267,36 @@ func TestOperationDescription_CheckParametersIgnored(t *testing.T) {
 	res := def.RunRule(nodes, ctx)
 
 	assert.Len(t, res, 0)
+}
 
+func TestOperationDescription_CheckServersIgnored(t *testing.T) {
+	yml := `paths:
+  /fish/paste:
+    servers:
+      - url: https://api.example.com/v1
+    post:
+      description: this is a description that is great and 10 words long at least
+      operationId: c`
+
+	path := "$"
+
+	var rootNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+	assert.NoError(t, mErr)
+
+	nodes, _ := utils.FindNodes([]byte(yml), path)
+
+	opts := make(map[string]string)
+	opts["minWords"] = "10"
+
+	rule := buildOpenApiTestRuleAction(path, "operation-description", "", opts)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), opts)
+	ctx.Index = index.NewSpecIndex(&rootNode)
+
+	def := OperationDescription{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 0)
 }
 
 func TestOperationDescription_CheckExtensionsIgnored(t *testing.T) {

--- a/functions/openapi/operation_tags.go
+++ b/functions/openapi/operation_tags.go
@@ -9,7 +9,6 @@ import (
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 // OperationTags is a rule that checks operations are using tags and they are not empty.
@@ -56,12 +55,13 @@ func (ot OperationTags) RunRule(nodes []*yaml.Node, context model.RuleFunctionCo
 				} else {
 					continue
 				}
-				if strings.Contains(strings.ToLower(currentVerb), "x-") {
-					skip = true
-					continue
-				}
-				// skip parameters, they are not an operation.
-				if currentVerb == v3.ParametersLabel {
+				// skip non-operations
+				switch currentVerb {
+				case
+					// No v2.*Label here, they're duplicates
+					v3.GetLabel, v3.PutLabel, v3.PostLabel, v3.DeleteLabel, v3.OptionsLabel, v3.HeadLabel, v3.PatchLabel, v3.TraceLabel:
+					// Ok, an operation
+				default:
 					skip = true
 					continue
 				}

--- a/functions/openapi/operation_tags_test.go
+++ b/functions/openapi/operation_tags_test.go
@@ -155,6 +155,34 @@ func TestOperationTags_RunRule_IgnoreParameters(t *testing.T) {
 	assert.Len(t, res, 0)
 }
 
+func TestOperationTags_RunRule_IgnoreServers(t *testing.T) {
+	yml := `paths:
+  /hello:
+    post:
+      tags:
+        - a
+        - b
+    servers:
+      - url: https://api.example.com/v1`
+
+	var rootNode yaml.Node
+	mErr := yaml.Unmarshal([]byte(yml), &rootNode)
+	assert.NoError(t, mErr)
+
+	path := "$"
+
+	nodes, _ := utils.FindNodes([]byte(yml), path)
+
+	rule := buildOpenApiTestRuleAction(path, "operation_tags", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Index = index.NewSpecIndex(&rootNode)
+
+	def := OperationTags{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 0)
+}
+
 func TestOperationTags_RunRule_IgnoreExtensions(t *testing.T) {
 
 	yml := `paths:


### PR DESCRIPTION
Fixes treating `servers` as an operation.

Seems cleaner to mark known operations as such, instead of filtering out known non-operations.