### PR TITLE
feat(pre-commit): improve default matching and docs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,5 @@
   language: golang
   entry: vacuum lint
   args: [--details]
-  files: ^(openapi|swagger)\.(json|ya?ml)$
+  types: [text]
+  files: (^|/)(openapi|swagger)\.(json|ya?ml)$

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ repos:
       - id: vacuum
 ```
 
-See the [hook config](./.pre-commit-hooks.yaml) here for details on what options the hook uses and what files it checks by default.
+See the [hook definition](./.pre-commit-hooks.yaml) here for details on what options the hook uses and what files it checks by default.
+
+If no filenames or more than one filename in your repository matches the default `files` pattern in the hook definition,
+the pattern needs to be overridden in your config so that it matches exactly one filename to lint at a time.
+To lint multiple files, specify the hook multiple times with the appropriate overrides.
 
 ## Build an interactive HTML report 
 


### PR DESCRIPTION
pre-commit passes all filenames to be checked to the invoked command, which does not work with vacuum's current behavior of taking only one filename at a time to lint.

On the other hand, sometimes there are multiple OpenAPI or Swagger specs in a repo that should be checked.

Additionally, there is no bullet proof way to recognize something being an OpenAPI or Swagger spec available for use in pre-commit at the moment.

Therefore, the default configuration is a balancing act between working out of the box without additional tweaks in usual setups, as well as providing means to override it to match cases where it doesn't.

Improve the documentation to note the configuration constraints, and ways to make it work if the default does not.

Improve also the default configuration to match conventional spec filenames also in subdirectories, not only in top level. Add also a `types` matcher to filter out non-text files possibly matched by the `files` pattern. (The `types` matcher can be overridden in user config as well in the unlikely case it happens to cause problems.)