### PR TITLE
Fixed `operation_descriptions` function to remedy #148

### DIFF
--- a/functions/openapi/operation_descriptions.go
+++ b/functions/openapi/operation_descriptions.go
@@ -54,6 +54,9 @@ func (od OperationDescription) RunRule(nodes []*yaml.Node, context model.RuleFun
 
 			if m%2 == 0 {
 				opMethod = method.Value
+				if skip {
+					skip = false
+				}
 				continue
 			}
 			// skip non-operations


### PR DESCRIPTION
the `skip` bit needed resetting when looking at a method.