### PR TITLE
Add vacuum executable to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ FROM debian:bullseye-slim
 WORKDIR /work
 COPY --from=0 /vacuum /
 
-ENTRYPOINT ["/vacuum"]
+ENV PATH=$PATH:/
+
+ENTRYPOINT ["vacuum"]


### PR DESCRIPTION
Add directory with vacuum executable to the PATH variable. 
This is slightly less confusing when you override the entrypoint. 
With this change you can just use the command.