### PR TITLE
refactor: use model.SeverityError throughout

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -186,7 +186,7 @@ func GetLintCommand() *cobra.Command {
 	cmd.Flags().BoolP("errors", "e", false, "Show errors only")
 	cmd.Flags().StringP("category", "c", "", "Show a single category of results")
 	cmd.Flags().BoolP("silent", "x", false, "Show nothing except the result.")
-	cmd.Flags().StringP("fail-severity", "n", "error", "Results of this level or above will trigger a failure exit code")
+	cmd.Flags().StringP("fail-severity", "n", model.SeverityError, "Results of this level or above will trigger a failure exit code")
 
 	regErr := cmd.RegisterFlagCompletionFunc("category", cobra.FixedCompletions([]string{
 		model.CategoryAll,
@@ -203,9 +203,9 @@ func GetLintCommand() *cobra.Command {
 		panic(regErr)
 	}
 	regErr = cmd.RegisterFlagCompletionFunc("fail-severity", cobra.FixedCompletions([]string{
-		"info",
-		"warn",
-		"error",
+		model.SeverityInfo,
+		model.SeverityWarn,
+		model.SeverityError,
 	}, cobra.ShellCompDirectiveNoFileComp))
 	if regErr != nil {
 		panic(regErr)
@@ -257,15 +257,15 @@ func processResults(results []*model.RuleFunctionResult, specData []string, snip
 		}
 
 		switch sev {
-		case "error":
+		case model.SeverityError:
 			sev = pterm.LightRed(sev)
-		case "warn":
+		case model.SeverityWarn:
 			sev = pterm.LightYellow("warning")
-		case "info":
+		case model.SeverityInfo:
 			sev = pterm.LightBlue(sev)
 		}
 
-		if errors && r.Rule.Severity != "error" {
+		if errors && r.Rule.Severity != model.SeverityError {
 			continue // only show errors
 		}
 

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/daveshanley/vacuum/model"
 	"io"
 	"os"
 	"testing"
@@ -133,7 +135,7 @@ func TestGetLintCommand_BadRuleset(t *testing.T) {
 
 func TestGetLintCommand_InvalidRuleset(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -141,7 +143,7 @@ func TestGetLintCommand_InvalidRuleset(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "I AM NOT A PATH <-- ",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -151,7 +153,7 @@ func TestGetLintCommand_InvalidRuleset(t *testing.T) {
       }
     }
   }
-}`
+}`, model.SeverityError)
 
 	tmp, _ := os.CreateTemp("", "")
 	_, _ = io.WriteString(tmp, json)

--- a/cmd/shared_functions.go
+++ b/cmd/shared_functions.go
@@ -63,14 +63,14 @@ func LoadCustomFunctions(functionsFlag string) (map[string]model.RuleFunction, e
 }
 
 func CheckFailureSeverity(failSeverityFlag string, errors int, warnings int, informs int) error {
-	if failSeverityFlag != "error" {
+	if failSeverityFlag != model.SeverityError {
 		switch failSeverityFlag {
-		case "warn":
+		case model.SeverityWarn:
 			if warnings > 0 {
 				return fmt.Errorf("failed linting, with %d errors and %d warnings", errors, warnings)
 			}
 			return nil
-		case "info":
+		case model.SeverityInfo:
 			if informs > 0 {
 				return fmt.Errorf("failed linting, with %d errors, %d warnings and %d informs",
 					errors, warnings, informs)

--- a/functions/core/alphabetical_test.go
+++ b/functions/core/alphabetical_test.go
@@ -21,7 +21,7 @@ func TestAlphabetical_RunRule_FailStringArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -45,7 +45,7 @@ func TestAlphabetical_RunRule_PassStringArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -66,7 +66,7 @@ func TestAlphabetical_RunRule_FailIntegerArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -87,7 +87,7 @@ func TestAlphabetical_RunRule_FailFloatArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -108,7 +108,7 @@ func TestAlphabetical_RunRule_SuccessIntegerArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -129,7 +129,7 @@ func TestAlphabetical_RunRule_SuccessFloatArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -150,7 +150,7 @@ func TestAlphabetical_RunRule_IgnoreBooleanArray(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -178,7 +178,7 @@ func TestAlphabetical_RunRule_ObjectFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["keyedBy"] = "nuggets"
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -206,7 +206,7 @@ func TestAlphabetical_RunRule_ObjectSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["keyedBy"] = "heat"
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -234,7 +234,7 @@ func TestAlphabetical_RunRule_ObjectIntegersSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["keyedBy"] = "heat"
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -262,7 +262,7 @@ func TestAlphabetical_RunRule_ObjectIntegersFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["keyedBy"] = "heat"
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -289,7 +289,7 @@ func TestAlphabetical_RunRule_ObjectFailNoKeyedBy(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "alphabetical", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule

--- a/functions/core/casing_test.go
+++ b/functions/core/casing_test.go
@@ -19,7 +19,7 @@ func TestCasing_RunRule_CamelSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "camel"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -41,7 +41,7 @@ func TestCasing_RunRule_CamelFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "camel"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 	def := &Casing{}
@@ -62,7 +62,7 @@ func TestCasing_RunRule_PascalSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "pascal"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 	def := &Casing{}
@@ -83,7 +83,7 @@ func TestCasing_RunRule_PascalFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "pascal"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -105,7 +105,7 @@ func TestCasing_RunRule_KebabSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "kebab"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -127,7 +127,7 @@ func TestCasing_RunRule_KebabFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "kebab"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -149,7 +149,7 @@ func TestCasing_RunRule_CobolSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "cobol"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -171,7 +171,7 @@ func TestCasing_RunRule_CobolFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "cobol"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -193,7 +193,7 @@ func TestCasing_RunRule_SnakeSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "snake"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -215,7 +215,7 @@ func TestCasing_RunRule_SnakeFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "snake"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -237,7 +237,7 @@ func TestCasing_RunRule_MacroSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "macro"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -259,7 +259,7 @@ func TestCasing_RunRule_MacroFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["type"] = "macro"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -282,7 +282,7 @@ func TestCasing_RunRule_CamelNoDigits_Success(t *testing.T) {
 	opts["type"] = "camel"
 	opts["disallowDigits"] = "true"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -305,7 +305,7 @@ func TestCasing_RunRule_CamelNoDigits_Fail(t *testing.T) {
 	opts["type"] = "camel"
 	opts["disallowDigits"] = "true"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -328,7 +328,7 @@ func TestCasing_RunRule_Snake_SeparatingChar_Success(t *testing.T) {
 	opts["type"] = "snake"
 	opts["separator.char"] = ","
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -351,7 +351,7 @@ func TestCasing_RunRule_Snake_SeparatingChar_Fail(t *testing.T) {
 	opts["type"] = "snake"
 	opts["separator.char"] = ","
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -375,7 +375,7 @@ func TestCasing_RunRule_Snake_AllowLeading_Success(t *testing.T) {
 	opts["separator.char"] = ","
 	opts["separator.allowLeading"] = "true"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -399,7 +399,7 @@ func TestCasing_RunRule_Snake_AllowLeading_Fail(t *testing.T) {
 	opts["separator.char"] = ","
 	opts["separator.allowLeading"] = "false"
 
-	rule := buildCoreTestRule(path, severityError, "casing", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 

--- a/functions/core/core_test.go
+++ b/functions/core/core_test.go
@@ -2,10 +2,6 @@ package core
 
 import "github.com/daveshanley/vacuum/model"
 
-const (
-	severityError = "error"
-)
-
 func buildCoreTestRule(given, severity, function, field string, functionOptions map[string]string) model.Rule {
 	return model.Rule{
 		Given:    given,

--- a/functions/core/defined_test.go
+++ b/functions/core/defined_test.go
@@ -28,7 +28,7 @@ func TestDefined_RunRule_Success(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	rule := buildCoreTestRule(path, severityError, "defined", "cake", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "defined", "cake", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 
@@ -48,7 +48,7 @@ func TestDefined_RunRule_Fail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	rule := buildCoreTestRule(path, severityError, "defined", "cake", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "defined", "cake", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 

--- a/functions/core/enumeration_test.go
+++ b/functions/core/enumeration_test.go
@@ -28,7 +28,7 @@ func TestEnumeration_RunRule_Success(t *testing.T) {
 	opts := make(map[string]string)
 	opts["values"] = "turkey, sprouts, presents, ham"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 
@@ -47,7 +47,7 @@ func TestEnumeration_RunRule_Fail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["values"] = "turkey, sprouts, presents, ham"
 
-	rule := buildCoreTestRule(path, severityError, "enumeration", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "enumeration", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 
@@ -65,7 +65,7 @@ func TestEnumeration_RunRule_FalseFail(t *testing.T) {
 
 	opts := make(map[string]string) // don't add opts.
 
-	rule := buildCoreTestRule(path, severityError, "enumeration", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "enumeration", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 

--- a/functions/core/falsy_test.go
+++ b/functions/core/falsy_test.go
@@ -24,7 +24,7 @@ tags:
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 4)
 
-	rule := buildCoreTestRule(path, severityError, "falsy", "description", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "falsy", "description", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 
@@ -51,7 +51,7 @@ notTags:
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 0)
 
-	rule := buildCoreTestRule(path, severityError, "falsy", "description", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "falsy", "description", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 
@@ -77,7 +77,7 @@ tags:
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 4)
 
-	rule := buildCoreTestRule(path, severityError, "Falsy", "description", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "Falsy", "description", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 

--- a/functions/core/length_test.go
+++ b/functions/core/length_test.go
@@ -36,7 +36,7 @@ paths:
 	ops := make(map[string]string)
 	ops["min"] = "3"
 
-	rule := buildCoreTestRule(path, severityError, "length", "paths", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "paths", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -64,7 +64,7 @@ paths:
 	ops := make(map[string]string)
 	ops["min"] = "4"
 
-	rule := buildCoreTestRule(path, severityError, "length", "paths", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "paths", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -92,7 +92,7 @@ paths:
 	ops := make(map[string]string)
 	ops["min"] = "4"
 
-	rule := buildCoreTestRule(path, severityError, "length", "paths", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "paths", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -118,7 +118,7 @@ tags:
 	ops := make(map[string]string)
 	ops["min"] = "6"
 
-	rule := buildCoreTestRule(path, severityError, "length", "tags", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "tags", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -144,7 +144,7 @@ tags:
 	ops := make(map[string]string)
 	ops["max"] = "2"
 
-	rule := buildCoreTestRule(path, severityError, "length", "tags", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "tags", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -173,7 +173,7 @@ tags:
 	ops["max"] = "4"
 	ops["min"] = "2"
 
-	rule := buildCoreTestRule(path, severityError, "length", "tags", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "tags", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -201,7 +201,7 @@ tags:
 	ops["max"] = "3"
 	ops["min"] = "2"
 
-	rule := buildCoreTestRule(path, severityError, "length", "description", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "description", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -229,7 +229,7 @@ tags:
 	ops["max"] = "9"
 	ops["min"] = "2"
 
-	rule := buildCoreTestRule(path, severityError, "length", "description", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "description", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -259,7 +259,7 @@ tags:
 	ops["max"] = "9"
 	ops["min"] = "2"
 
-	rule := buildCoreTestRule(path, severityError, "length", "description", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "description", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -287,7 +287,7 @@ tags:
 	ops["max"] = "9"
 	ops["min"] = "3"
 
-	rule := buildCoreTestRule(path, severityError, "length", "", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -316,7 +316,7 @@ tags:
 	ops["max"] = "1"
 	ops["min"] = "0"
 
-	rule := buildCoreTestRule(path, severityError, "length", "", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -343,7 +343,7 @@ tags:`
 	ops["max"] = "9"
 	ops["min"] = "2"
 
-	rule := buildCoreTestRule(path, severityError, "length", "description", ops)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "description", ops)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), ops)
 	ctx.Given = path
 
@@ -367,7 +367,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	rule := buildCoreTestRule(path, severityError, "length", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Options = nil
 	ctx.Given = path
@@ -393,7 +393,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	rule := buildCoreTestRule(path, severityError, "length", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "length", "", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Options = "not options at all"
 	ctx.Given = path

--- a/functions/core/pattern_test.go
+++ b/functions/core/pattern_test.go
@@ -28,7 +28,7 @@ func TestPattern_RunRule_PatternMatchSuccess(t *testing.T) {
 	opts := make(map[string]string)
 	opts["match"] = "[abc]+"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -46,7 +46,7 @@ func TestPattern_RunRule_PatternNothingSupplied(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "", nil)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -67,7 +67,7 @@ func TestPattern_RunRule_PatternNotMatchError(t *testing.T) {
 	opts := make(map[string]string)
 	opts["notMatch"] = "[[abc)"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "carpet", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "carpet", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -88,7 +88,7 @@ func TestPattern_RunRule_PatternMatchFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["match"] = "[abc]+"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "carpet", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "carpet", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -109,7 +109,7 @@ func TestPattern_RunRule_PatternMatchError(t *testing.T) {
 	opts := make(map[string]string)
 	opts["match"] = "([abc]"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "carpet", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "carpet", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -130,7 +130,7 @@ func TestPattern_RunRule_PatternNotMatchFail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["notMatch"] = `\w{3}\d`
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "pizza", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "pizza", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -152,7 +152,7 @@ func TestPattern_RunRule_UseFieldName(t *testing.T) {
 	opts := make(map[string]string)
 	opts["match"] = "cake"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "sleep", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "sleep", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -174,7 +174,7 @@ func TestPattern_RunRule_ContainMap(t *testing.T) {
 	opts := make(map[string]string)
 	opts["match"] = "until"
 
-	rule := buildCoreTestRule(path, severityError, "pattern", "sleep", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "sleep", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
 	ctx.Given = path
 	ctx.Rule = &rule

--- a/functions/core/truthy_test.go
+++ b/functions/core/truthy_test.go
@@ -35,7 +35,7 @@ tags:
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 4)
 
-	rule := buildCoreTestRule(path, severityError, "truthy", "description", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "truthy", "description", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -63,7 +63,7 @@ notTags:
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 0)
 
-	rule := buildCoreTestRule(path, severityError, "truthy", "description", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "truthy", "description", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -92,7 +92,7 @@ tags:
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 4)
 
-	rule := buildCoreTestRule(path, severityError, "truthy", "description", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "truthy", "description", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 	ctx.Rule = &rule
@@ -119,7 +119,7 @@ func TestTruthy_RunRule_ArrayTest(t *testing.T) {
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	rule := buildCoreTestRule(path, severityError, "truthy", "rags", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "truthy", "rags", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 	ctx.Rule = &rule

--- a/functions/core/undefined_test.go
+++ b/functions/core/undefined_test.go
@@ -28,7 +28,7 @@ func TestUndefined_RunRule_Success(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	rule := buildCoreTestRule(path, severityError, "undefined", "cake", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "undefined", "cake", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 
@@ -48,7 +48,7 @@ func TestUndefined_RunRule_Fail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	rule := buildCoreTestRule(path, severityError, "undefined", "cake", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "undefined", "cake", nil)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Given = path
 

--- a/functions/core/xor_test.go
+++ b/functions/core/xor_test.go
@@ -27,7 +27,7 @@ func TestXor_RunRule_SuccessPropsStringArray(t *testing.T) {
 	opts := make(map[string][]string)
 	opts["properties"] = []string{"sparkles", "rainbows"}
 
-	rule := buildCoreTestRule(path, severityError, "xor", "", nil)
+	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", nil)
 	ctx := model.RuleFunctionContext{RuleAction: model.CastToRuleAction(rule.Then), Rule: &rule, Options: opts}
 	ctx.Given = path
 
@@ -51,7 +51,7 @@ func TestXor_RunRule_Success(t *testing.T) {
 	opts := make(map[string]string)
 	opts["properties"] = "sparkles, rainbows"
 
-	rule := buildCoreTestRule(path, severityError, "xor", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -74,7 +74,7 @@ func TestXor_RunRule_NoProps(t *testing.T) {
 
 	opts := make(map[string]string)
 
-	rule := buildCoreTestRule(path, severityError, "xor", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -98,7 +98,7 @@ func TestXor_RunRule_Fail(t *testing.T) {
 	opts := make(map[string]string)
 	opts["properties"] = "sparkles, shiny"
 
-	rule := buildCoreTestRule(path, severityError, "xor", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 
@@ -122,7 +122,7 @@ func TestXor_RunRule_Fail_AllUndefined(t *testing.T) {
 	opts := make(map[string]string)
 	opts["properties"] = "clouds, rain"
 
-	rule := buildCoreTestRule(path, severityError, "xor", "", opts)
+	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
 	ctx.Given = path
 

--- a/html-report/build_report.go
+++ b/html-report/build_report.go
@@ -95,13 +95,13 @@ func (html htmlReport) GenerateReport(test bool) []byte {
 		},
 		"ruleSeverityIcon": func(sev string) string {
 			switch sev {
-			case "error":
+			case model.SeverityError:
 				return "❌"
-			case "warn":
+			case model.SeverityWarn:
 				return "⚠️"
-			case "info":
+			case model.SeverityInfo:
 				return "🔵"
-			case "hint":
+			case model.SeverityHint:
 				return "💠"
 			}
 			return ""

--- a/model/results.go
+++ b/model/results.go
@@ -85,11 +85,11 @@ func (rr *RuleResultSet) GenerateSpectralReport(source string) []reports.Spectra
 
 		sev := 1
 		switch result.Rule.Severity {
-		case "error":
+		case SeverityError:
 			sev = 0
-		case "info":
+		case SeverityInfo:
 			sev = 2
-		case "hint":
+		case SeverityHint:
 			sev = 3
 		}
 
@@ -128,7 +128,7 @@ func (rr *RuleResultSet) GetErrorCount() int {
 	if rr.ErrorCount > 0 {
 		return rr.ErrorCount
 	} else {
-		rr.ErrorCount = getCount(rr, severityError)
+		rr.ErrorCount = getCount(rr, SeverityError)
 		return rr.ErrorCount
 	}
 }
@@ -138,7 +138,7 @@ func (rr *RuleResultSet) GetWarnCount() int {
 	if rr.WarnCount > 0 {
 		return rr.WarnCount
 	} else {
-		rr.WarnCount = getCount(rr, severityWarn)
+		rr.WarnCount = getCount(rr, SeverityWarn)
 		return rr.WarnCount
 	}
 }
@@ -148,7 +148,7 @@ func (rr *RuleResultSet) GetInfoCount() int {
 	if rr.InfoCount > 0 {
 		return rr.InfoCount
 	} else {
-		rr.InfoCount = getCount(rr, severityInfo)
+		rr.InfoCount = getCount(rr, SeverityInfo)
 		return rr.InfoCount
 	}
 }
@@ -188,7 +188,7 @@ func (rr *RuleResultSet) GetErrorsByRuleCategory(category string) []*RuleFunctio
 	allCats := rr.GetResultsByRuleCategory(category)
 	for _, cat := range allCats {
 		switch cat.Rule.Severity {
-		case severityError:
+		case SeverityError:
 			filtered = append(filtered, cat)
 		}
 	}
@@ -201,7 +201,7 @@ func (rr *RuleResultSet) GetWarningsByRuleCategory(category string) []*RuleFunct
 	allCats := rr.GetResultsByRuleCategory(category)
 	for _, cat := range allCats {
 		switch cat.Rule.Severity {
-		case severityWarn:
+		case SeverityWarn:
 			filtered = append(filtered, cat)
 		}
 	}
@@ -214,7 +214,7 @@ func (rr *RuleResultSet) GetInfoByRuleCategory(category string) []*RuleFunctionR
 	allCats := rr.GetResultsByRuleCategory(category)
 	for _, cat := range allCats {
 		switch cat.Rule.Severity {
-		case severityInfo:
+		case SeverityInfo:
 			filtered = append(filtered, cat)
 		}
 	}
@@ -227,7 +227,7 @@ func (rr *RuleResultSet) GetHintByRuleCategory(category string) []*RuleFunctionR
 	allCats := rr.GetResultsByRuleCategory(category)
 	for _, cat := range allCats {
 		switch cat.Rule.Severity {
-		case severityHint:
+		case SeverityHint:
 			filtered = append(filtered, cat)
 		}
 	}

--- a/model/results_test.go
+++ b/model/results_test.go
@@ -11,22 +11,22 @@ func TestRuleResultSet_PrepareForSerialization(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityError,
+		Severity:     SeverityError,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 1, Column: 10}, EndNode: &yaml.Node{Line: 20, Column: 20}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 1, Column: 40}, EndNode: &yaml.Node{Line: 50, Column: 30}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 1, Column: 15}, EndNode: &yaml.Node{Line: 100, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 1, Column: 1999}, EndNode: &yaml.Node{Line: 8989899, Column: 10}}
 

--- a/model/rules.go
+++ b/model/rules.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	severityError        = "error"
-	severityWarn         = "warn"
-	severityInfo         = "info"
-	severityHint         = "hint"
+	SeverityError        = "error"
+	SeverityWarn         = "warn"
+	SeverityInfo         = "info"
+	SeverityHint         = "hint"
 	CategoryExamples     = "examples"
 	CategoryOperations   = "operations"
 	CategoryInfo         = "information"
@@ -115,13 +115,13 @@ type RuleFunctionSchema struct {
 // then -1 is returned.
 func (r *Rule) GetSeverityAsIntValue() int {
 	switch r.Severity {
-	case severityError:
+	case SeverityError:
 		return 0
-	case severityWarn:
+	case SeverityWarn:
 		return 1
-	case severityInfo:
+	case SeverityInfo:
 		return 2
-	case severityHint:
+	case SeverityHint:
 		return 3
 	}
 	return -1

--- a/model/rules_test.go
+++ b/model/rules_test.go
@@ -49,7 +49,7 @@ func TestNewRuleResultSet(t *testing.T) {
 	r1 := RuleFunctionResult{
 		Message: "pip",
 		Rule: &Rule{
-			Severity: severityError,
+			Severity: SeverityError,
 		},
 	}
 	results := NewRuleResultSet([]RuleFunctionResult{r1})
@@ -61,13 +61,13 @@ func TestNewRuleResultSet(t *testing.T) {
 func TestRuleResults_GetErrorCount(t *testing.T) {
 
 	r1 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityError,
+		Severity: SeverityError,
 	}}
 	r2 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityError,
+		Severity: SeverityError,
 	}}
 	r3 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityWarn,
+		Severity: SeverityWarn,
 	}}
 
 	results := &RuleResultSet{Results: []*RuleFunctionResult{r1, r2, r3}}
@@ -80,13 +80,13 @@ func TestRuleResults_GetErrorCount(t *testing.T) {
 func TestRuleResults_GetWarnCount(t *testing.T) {
 
 	r1 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityInfo,
+		Severity: SeverityInfo,
 	}}
 	r2 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityError,
+		Severity: SeverityError,
 	}}
 	r3 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityWarn,
+		Severity: SeverityWarn,
 	}}
 
 	results := &RuleResultSet{Results: []*RuleFunctionResult{r1, r2, r3}}
@@ -99,13 +99,13 @@ func TestRuleResults_GetWarnCount(t *testing.T) {
 func TestRuleResults_GetInfoCount(t *testing.T) {
 
 	r1 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityInfo,
+		Severity: SeverityInfo,
 	}}
 	r2 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityInfo,
+		Severity: SeverityInfo,
 	}}
 	r3 := &RuleFunctionResult{Rule: &Rule{
-		Severity: severityWarn,
+		Severity: SeverityWarn,
 	}}
 
 	results := &RuleResultSet{Results: []*RuleFunctionResult{r1, r2, r3}}
@@ -118,15 +118,15 @@ func TestRuleResults_GetInfoCount(t *testing.T) {
 func TestRuleResultSet_GetResultsByRuleCategory(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}}
 	r2 := RuleFunctionResult{Rule: &Rule{
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}}
 	r3 := RuleFunctionResult{Rule: &Rule{
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryOperations],
 	}}
 
@@ -142,13 +142,13 @@ func TestRuleResultSet_GetResultsByRuleCategoryWithLimit(t *testing.T) {
 
 	rule1 := &Rule{
 		Id:           "one",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}
 
 	rule2 := &Rule{
 		Id:           "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}
 
@@ -180,17 +180,17 @@ func TestRuleResultSet_SortResultsByLineNumber(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "ten",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "twenty",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 20}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryOperations],
 	}, StartNode: &yaml.Node{Line: 3}}
 
@@ -207,23 +207,23 @@ func TestRuleResultSet_CheckCategoryCounts(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityError,
+		Severity:     SeverityError,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 20}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 3}}
 
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 3}}
 
@@ -239,22 +239,22 @@ func TestRuleResultSet_GenerateSpectralReport(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityError,
+		Severity:     SeverityError,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 
@@ -266,22 +266,22 @@ func TestRuleResultSet_CalculateCategoryHealth_Errors(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityError,
+		Severity:     SeverityError,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 
@@ -294,22 +294,22 @@ func TestRuleResultSet_CalculateCategoryHealth_Warnings(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 
@@ -323,7 +323,7 @@ func TestRuleResultSet_CalculateCategoryHealth_Warnings_Lots(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		r = append(r, RuleFunctionResult{Rule: &Rule{
 			Description:  "one",
-			Severity:     severityWarn,
+			Severity:     SeverityWarn,
 			RuleCategory: RuleCategories[CategoryInfo],
 		}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}})
 	}
@@ -338,7 +338,7 @@ func TestRuleResultSet_CalculateCategoryHealth_Errors_Lots(t *testing.T) {
 	for i := 0; i < 900; i++ {
 		r = append(r, RuleFunctionResult{Rule: &Rule{
 			Description:  fmt.Sprintf("%d", i),
-			Severity:     severityError,
+			Severity:     SeverityError,
 			RuleCategory: RuleCategories[CategoryInfo],
 		}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}})
 	}
@@ -353,22 +353,22 @@ func TestRuleResultSet_GetRuleResultsForCategory(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategorySecurity],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 
@@ -381,22 +381,22 @@ func TestRuleResultSet_GetRuleResultsForCategoryAll(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategorySecurity],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 
@@ -409,28 +409,28 @@ func TestRule_GetSeverityAsIntValue(t *testing.T) {
 
 	r1 := &Rule{
 		Description:  "one",
-		Severity:     severityError,
+		Severity:     SeverityError,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}
 	assert.Equal(t, 0, r1.GetSeverityAsIntValue())
 
 	r2 := &Rule{
 		Description:  "two",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}
 	assert.Equal(t, 1, r2.GetSeverityAsIntValue())
 
 	r3 := &Rule{
 		Description:  "three",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}
 	assert.Equal(t, 2, r3.GetSeverityAsIntValue())
 
 	r4 := &Rule{
 		Description:  "four",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}
 	assert.Equal(t, 3, r4.GetSeverityAsIntValue())
@@ -448,27 +448,27 @@ func TestRuleResultsForCategory_Sort(t *testing.T) {
 
 	r1 := RuleFunctionResult{Rule: &Rule{
 		Description:  "one",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r2 := RuleFunctionResult{Rule: &Rule{
 		Description:  "two",
-		Severity:     severityInfo,
+		Severity:     SeverityInfo,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r3 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityWarn,
+		Severity:     SeverityWarn,
 		RuleCategory: RuleCategories[CategorySecurity],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r4 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityHint,
+		Severity:     SeverityHint,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 	r5 := RuleFunctionResult{Rule: &Rule{
 		Description:  "three",
-		Severity:     severityError,
+		Severity:     SeverityError,
 		RuleCategory: RuleCategories[CategorySchemas],
 	}, StartNode: &yaml.Node{Line: 10, Column: 10}, EndNode: &yaml.Node{Line: 10, Column: 10}}
 

--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -101,7 +101,7 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         "validation",
-		Severity:     "error",
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "blank",
 		},
@@ -204,7 +204,7 @@ func ApplyRules(ruleSet *rulesets.RuleSet, spec []byte) ([]model.RuleFunctionRes
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         "validation",
-		Severity:     "error",
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "blank",
 		},

--- a/motor/rule_applicator_test.go
+++ b/motor/rule_applicator_test.go
@@ -1,6 +1,7 @@
 package motor
 
 import (
+	"fmt"
 	"github.com/daveshanley/vacuum/model"
 	"github.com/daveshanley/vacuum/rulesets"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,7 @@ func TestApplyRules_PostResponseFailure(t *testing.T) {
 
 func TestApplyRules_TruthyTest_MultipleElements_Fail(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "truthy-test": {
@@ -85,7 +86,7 @@ func TestApplyRules_TruthyTest_MultipleElements_Fail(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.info.contact",
-      "severity": "error",
+      "severity": "%s",
       "then": [
 		{
         	"function": "truthy",
@@ -103,7 +104,7 @@ func TestApplyRules_TruthyTest_MultipleElements_Fail(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, _ := rc.ComposeRuleSet([]byte(json))
 	burgershop, _ := os.ReadFile("../model/test_files/burgershop.openapi.yaml")
@@ -116,7 +117,7 @@ func TestApplyRules_TruthyTest_MultipleElements_Fail(t *testing.T) {
 
 func TestApplyRules_LengthTestFail(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test": {
@@ -124,7 +125,7 @@ func TestApplyRules_LengthTestFail(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.paths./burgers.post.requestBody.content.application/json",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "examples",
@@ -135,7 +136,7 @@ func TestApplyRules_LengthTestFail(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -151,7 +152,7 @@ func TestApplyRules_LengthTestFail(t *testing.T) {
 
 func TestApplyRules_LengthTestSuccess(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test": {
@@ -159,7 +160,7 @@ func TestApplyRules_LengthTestSuccess(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.paths./burgers.post.requestBody.content.application/json",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "examples",
@@ -171,7 +172,7 @@ func TestApplyRules_LengthTestSuccess(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -185,7 +186,7 @@ func TestApplyRules_LengthTestSuccess(t *testing.T) {
 
 func TestApplyRules_PatternTestSuccess_NotMatch(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "pattern-test-description": {
@@ -193,7 +194,7 @@ func TestApplyRules_PatternTestSuccess_NotMatch(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$..description",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "pattern",
 		"functionOptions" : { 
@@ -203,7 +204,7 @@ func TestApplyRules_PatternTestSuccess_NotMatch(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -217,7 +218,7 @@ func TestApplyRules_PatternTestSuccess_NotMatch(t *testing.T) {
 
 func TestApplyRules_AlphabeticalTestFail_Tags(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "alpha-test-description": {
@@ -225,7 +226,7 @@ func TestApplyRules_AlphabeticalTestFail_Tags(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.tags",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "alphabetical",
 		"functionOptions" : { 
@@ -235,7 +236,7 @@ func TestApplyRules_AlphabeticalTestFail_Tags(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -249,7 +250,7 @@ func TestApplyRules_AlphabeticalTestFail_Tags(t *testing.T) {
 
 func TestApplyRules_LengthFail_Tags(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -257,7 +258,7 @@ func TestApplyRules_LengthFail_Tags(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.tags",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"functionOptions" : { 
@@ -267,7 +268,7 @@ func TestApplyRules_LengthFail_Tags(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -281,7 +282,7 @@ func TestApplyRules_LengthFail_Tags(t *testing.T) {
 
 func TestApplyRules_LengthSuccess_Description(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -289,7 +290,7 @@ func TestApplyRules_LengthSuccess_Description(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.components.schemas.Burger",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -300,7 +301,7 @@ func TestApplyRules_LengthSuccess_Description(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -314,7 +315,7 @@ func TestApplyRules_LengthSuccess_Description(t *testing.T) {
 
 func TestApplyRules_Xor_Success(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "xor-test-description": {
@@ -329,7 +330,7 @@ func TestApplyRules_Xor_Success(t *testing.T) {
         "$.paths[*][*]..headers[*].examples[*]",
         "$.components.headers[*].examples[*]"
       ],
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "xor",
 		"functionOptions" : { 
@@ -339,7 +340,7 @@ func TestApplyRules_Xor_Success(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -353,7 +354,7 @@ func TestApplyRules_Xor_Success(t *testing.T) {
 
 func TestApplyRules_Xor_Fail(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "xor-test-description": {
@@ -368,7 +369,7 @@ func TestApplyRules_Xor_Fail(t *testing.T) {
         "$.paths[*][*]..headers[*].examples[*]",
         "$.components.headers[*].examples[*]"
       ],
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "xor",
 		"functionOptions" : { 
@@ -378,7 +379,7 @@ func TestApplyRules_Xor_Fail(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -392,7 +393,7 @@ func TestApplyRules_Xor_Fail(t *testing.T) {
 
 func TestApplyRules_BadData(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test": {
@@ -400,7 +401,7 @@ func TestApplyRules_BadData(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.paths./burgers.post.requestBody.content.application/json",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "examples",
@@ -412,7 +413,7 @@ func TestApplyRules_BadData(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -435,7 +436,7 @@ func TestApplyRules_CircularReferences(t *testing.T) {
 
 func TestApplyRules_LengthSuccess_Description_Rootnode(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -443,7 +444,7 @@ func TestApplyRules_LengthSuccess_Description_Rootnode(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -454,7 +455,7 @@ func TestApplyRules_LengthSuccess_Description_Rootnode(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -468,7 +469,7 @@ func TestApplyRules_LengthSuccess_Description_Rootnode(t *testing.T) {
 
 func TestApplyRules_Length_Description_BadPath(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -476,7 +477,7 @@ func TestApplyRules_Length_Description_BadPath(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "I AM NOT A PATH",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -487,7 +488,7 @@ func TestApplyRules_Length_Description_BadPath(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -504,7 +505,7 @@ func TestApplyRules_Length_Description_BadPath(t *testing.T) {
 
 func TestApplyRules_Length_Description_BadConfig(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -512,7 +513,7 @@ func TestApplyRules_Length_Description_BadConfig(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$.info",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -522,7 +523,7 @@ func TestApplyRules_Length_Description_BadConfig(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -538,7 +539,7 @@ func TestApplyRules_Length_Description_BadConfig(t *testing.T) {
 
 func TestApplyRulesToRuleSet_Length_Description_BadPath(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -546,7 +547,7 @@ func TestApplyRulesToRuleSet_Length_Description_BadPath(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "I AM NOT A PATH",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -557,7 +558,7 @@ func TestApplyRulesToRuleSet_Length_Description_BadPath(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)
@@ -576,7 +577,7 @@ func TestApplyRulesToRuleSet_Length_Description_BadPath(t *testing.T) {
 
 func TestApplyRulesToRuleSet_CircularReferences(t *testing.T) {
 
-	json := `{
+	json := fmt.Sprintf(`{
   "documentationUrl": "quobix.com",
   "rules": {
     "length-test-description": {
@@ -584,7 +585,7 @@ func TestApplyRulesToRuleSet_CircularReferences(t *testing.T) {
       "recommended": true,
       "type": "style",
       "given": "$",
-      "severity": "error",
+      "severity": "%s",
       "then": {
         "function": "length",
 		"field": "required",
@@ -595,7 +596,7 @@ func TestApplyRulesToRuleSet_CircularReferences(t *testing.T) {
     }
   }
 }
-`
+`, model.SeverityError)
 	rc := CreateRuleComposer()
 	rs, err := rc.ComposeRuleSet([]byte(json))
 	assert.NoError(t, err)

--- a/rulesets/ruleset_functions.go
+++ b/rulesets/ruleset_functions.go
@@ -23,7 +23,7 @@ func GetContactPropertiesRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  false,
 		Type:         validation,
-		Severity:     info,
+		Severity:     model.SeverityInfo,
 		Then: []model.RuleAction{
 			{
 				Field:    "name",
@@ -55,7 +55,7 @@ func GetInfoContactRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Field:    "contact",
 			Function: "truthy",
@@ -77,7 +77,7 @@ func GetInfoDescriptionRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Field:    "description",
 			Function: "truthy",
@@ -99,7 +99,7 @@ func GetInfoLicenseRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Type:         style,
-		Severity:     info,
+		Severity:     model.SeverityInfo,
 		Then: model.RuleAction{
 			Field:    "license",
 			Function: "truthy",
@@ -121,7 +121,7 @@ func GetInfoLicenseUrlRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Type:         style,
-		Severity:     info,
+		Severity:     model.SeverityInfo,
 		Then: model.RuleAction{
 			Field:    "url",
 			Function: "truthy",
@@ -148,7 +148,7 @@ func GetNoEvalInMarkdownRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryValidation],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function:        "noEvalDescription",
 			FunctionOptions: fo,
@@ -176,7 +176,7 @@ func GetNoScriptTagsInMarkdownRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryValidation],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function:        "noEvalDescription",
 			FunctionOptions: fo,
@@ -203,7 +203,7 @@ func GetOpenApiTagsAlphabeticalRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryTags],
 		Type:         style,
-		Severity:     info,
+		Severity:     model.SeverityInfo,
 		Then: model.RuleAction{
 			Function:        "alphabetical",
 			FunctionOptions: fo,
@@ -240,7 +240,7 @@ func GetOpenApiTagsRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryTags],
 		Recommended:  false,
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Field:           "tags",
 			Function:        "schema",
@@ -277,7 +277,7 @@ func GetOAS2APISchemesRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Field:           "schemes",
 			Function:        "schema",
@@ -303,7 +303,7 @@ func GetOAS2HostNotExampleRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  true,
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function:        "pattern",
 			FunctionOptions: opts,
@@ -329,7 +329,7 @@ func GetOAS3HostNotExampleRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  false,
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function:        "pattern",
 			FunctionOptions: opts,
@@ -354,7 +354,7 @@ func GetOAS2HostTrailingSlashRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  true,
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function:        "pattern",
 			FunctionOptions: opts,
@@ -379,7 +379,7 @@ func GetOAS3HostTrailingSlashRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Recommended:  false,
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Field:           "url",
 			Function:        "pattern",
@@ -405,7 +405,7 @@ func GetOperationDescriptionRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryDescriptions],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function:        "oasDescriptions",
 			FunctionOptions: opts,
@@ -426,7 +426,7 @@ func GetOAS2ParameterDescriptionRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryDescriptions],
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasParamDescriptions",
 		},
@@ -446,7 +446,7 @@ func GetOAS3ParameterDescriptionRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryDescriptions],
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasParamDescriptions",
 		},
@@ -467,7 +467,7 @@ func GetDescriptionDuplicationRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryDescriptions],
 		Type:         validation,
-		Severity:     info,
+		Severity:     model.SeverityInfo,
 		Then: model.RuleAction{
 			Function: "oasDescriptionDuplication",
 		},
@@ -487,7 +487,7 @@ func GetComponentDescriptionsRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryDescriptions],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasComponentDescriptions",
 		},
@@ -507,7 +507,7 @@ func GetAPIServersRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryValidation],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasAPIServers",
 		},
@@ -531,7 +531,7 @@ func GetOperationIdValidInUrlRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Field:           "operationId",
 			Function:        "pattern",
@@ -555,7 +555,7 @@ func GetOperationTagsRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryTags],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasOperationTags",
 		},
@@ -578,7 +578,7 @@ func GetPathDeclarationsMustExistRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function:        "pattern",
 			FunctionOptions: opts,
@@ -603,7 +603,7 @@ func GetPathNoTrailingSlashRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function:        "pattern",
 			FunctionOptions: opts,
@@ -628,7 +628,7 @@ func GetPathNotIncludeQueryRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function:        "pattern",
 			FunctionOptions: opts,
@@ -650,7 +650,7 @@ func GetTagDescriptionRequiredRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryTags],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Field:    "description",
 			Function: "truthy",
@@ -671,7 +671,7 @@ func GetTypedEnumRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "typedEnum",
 		},
@@ -692,7 +692,7 @@ func GetPathParamsRule() *model.Rule {
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Recommended:  true,
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasPathParam",
 		},
@@ -712,7 +712,7 @@ func GetGlobalOperationTagsRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryTags],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasTagDefined",
 		},
@@ -732,7 +732,7 @@ func GetOperationParametersRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasOpParams",
 		},
@@ -754,7 +754,7 @@ func GetOAS2FormDataConsumesRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasOpFormDataConsumeCheck",
 		},
@@ -774,7 +774,7 @@ func GetOAS2PolymorphicAnyOfRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasPolymorphicAnyOf",
 		},
@@ -794,7 +794,7 @@ func GetOAS2PolymorphicOneOfRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasPolymorphicOneOf",
 		},
@@ -814,7 +814,7 @@ func GetOAS2SchemaRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryValidation],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasDocumentSchema",
 		},
@@ -834,7 +834,7 @@ func GetOAS3SchemaRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasDocumentSchema",
 		},
@@ -854,7 +854,7 @@ func GetOperationIdUniqueRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasOpIdUnique",
 		},
@@ -874,7 +874,7 @@ func GetOperationSingleTagRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryTags],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasOpSingleTag",
 		},
@@ -894,7 +894,7 @@ func GetOAS2APIHostRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 		Type:         style,
-		Severity:     info,
+		Severity:     model.SeverityInfo,
 		Then: model.RuleAction{
 			Field:    "host",
 			Function: "truthy",
@@ -915,7 +915,7 @@ func GetOperationIdRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasOpId",
 		},
@@ -935,7 +935,7 @@ func GetOperationSuccessResponseRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Field:    "responses",
 			Function: "oasOpSuccessResponse",
@@ -956,7 +956,7 @@ func GetDuplicatedEntryInEnumRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "duplicatedEnum",
 		},
@@ -976,7 +976,7 @@ func GetNoRefSiblingsRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "refSiblings",
 		},
@@ -996,7 +996,7 @@ func GetOAS3UnusedComponentRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasUnusedComponent",
 		},
@@ -1016,7 +1016,7 @@ func GetOAS2UnusedComponentRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasUnusedComponent",
 		},
@@ -1039,7 +1039,7 @@ func GetOAS3SecurityDefinedRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySecurity],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function:        "oasOpSecurityDefined",
 			FunctionOptions: oasSecurityPath,
@@ -1060,7 +1060,7 @@ func GetOAS2SecurityDefinedRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySecurity],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oas2OpSecurityDefined",
 		},
@@ -1080,7 +1080,7 @@ func GetOAS2DiscriminatorRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategorySchemas],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "oasDiscriminator",
 		},
@@ -1100,7 +1100,7 @@ func GetOAS3ExamplesRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryExamples],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasExample",
 		},
@@ -1120,7 +1120,7 @@ func GetOAS2ExamplesRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryExamples],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasExample",
 		},
@@ -1140,7 +1140,7 @@ func NoAmbiguousPaths() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     err,
+		Severity:     model.SeverityError,
 		Then: model.RuleAction{
 			Function: "ambiguousPaths",
 		},
@@ -1160,7 +1160,7 @@ func GetNoVerbsInPathRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         style,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "noVerbsInPath",
 		},
@@ -1180,7 +1180,7 @@ func GetPathsKebabCaseRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "pathsKebabCase",
 		},
@@ -1200,7 +1200,7 @@ func GetOperationErrorResponseRule() *model.Rule {
 		Recommended:  false,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Type:         validation,
-		Severity:     warn,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasOpErrorResponse",
 		},

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -20,10 +20,6 @@ import (
 var rulesetSchema string
 
 const (
-	warn                              = "warn"
-	err                               = "error"
-	info                              = "info"
-	hint                              = "hint"
 	style                             = "style"
 	validation                        = "validation"
 	noVerbsInPath                     = "no-http-verbs-in-path"
@@ -202,7 +198,7 @@ func (rsm ruleSetsModel) GenerateRuleSetFromSuppliedRuleSet(ruleset *RuleSet) *R
 			}
 
 			switch evalStr {
-			case err, warn, info, hint:
+			case model.SeverityError, model.SeverityWarn, model.SeverityInfo, model.SeverityHint:
 				rs.Rules[k].Severity = evalStr
 			case SpectralOff:
 				delete(rs.Rules, k) // remove it completely

--- a/rulesets/rulesets_test.go
+++ b/rulesets/rulesets_test.go
@@ -1,6 +1,8 @@
 package rulesets
 
 import (
+	"fmt"
+	"github.com/daveshanley/vacuum/model"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -149,12 +151,12 @@ rules:
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_OverrideNotFound(t *testing.T) {
 
-	yaml := `extends:
+	yaml := fmt.Sprintf(`extends:
   -
     - spectral:oas
     - off
 rules:
- soda-pop: "warn"`
+ soda-pop: "%s"`, model.SeverityWarn)
 
 	def := BuildDefaultRuleSets()
 	rs, err := CreateRuleSetFromData([]byte(yaml))
@@ -166,12 +168,12 @@ rules:
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_All_OverrideNotFound(t *testing.T) {
 
-	yaml := `extends:
+	yaml := fmt.Sprintf(`extends:
   -
     - spectral:oas
     - all
 rules:
- soda-pop: "warn"`
+ soda-pop: "%s"`, model.SeverityWarn)
 
 	def := BuildDefaultRuleSets()
 	rs, _ := CreateRuleSetFromData([]byte(yaml))
@@ -198,18 +200,18 @@ rules:
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Rec_SeverityInfo(t *testing.T) {
 
-	yaml := `extends:
+	yaml := fmt.Sprintf(`extends:
   -
     - spectral:oas
     - recommended
 rules:
- operation-success-response: "hint"`
+ operation-success-response: "%s"`, model.SeverityHint)
 
 	def := BuildDefaultRuleSets()
 	rs, _ := CreateRuleSetFromData([]byte(yaml))
 	override := def.GenerateRuleSetFromSuppliedRuleSet(rs)
 	assert.Len(t, override.Rules, totalRecommendedRules)
-	assert.Equal(t, "hint", override.Rules["operation-success-response"].Severity)
+	assert.Equal(t, model.SeverityHint, override.Rules["operation-success-response"].Severity)
 }
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_EnableRules(t *testing.T) {
@@ -227,8 +229,8 @@ rules:
 	rs, _ := CreateRuleSetFromData([]byte(yaml))
 	override := def.GenerateRuleSetFromSuppliedRuleSet(rs)
 	assert.Len(t, override.Rules, 2)
-	assert.Equal(t, "warn", override.Rules["operation-success-response"].Severity)
-	assert.Equal(t, "warn", override.Rules["info-contact"].Severity)
+	assert.Equal(t, model.SeverityWarn, override.Rules["operation-success-response"].Severity)
+	assert.Equal(t, model.SeverityWarn, override.Rules["info-contact"].Severity)
 }
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_EnableRulesNotFound(t *testing.T) {

--- a/vacuum-report/vacuum_report_test.go
+++ b/vacuum-report/vacuum_report_test.go
@@ -136,7 +136,7 @@ func testhelp_generateReport() *VacuumReport {
 
 	r1 := model.RuleFunctionResult{Rule: &model.Rule{
 		Description:  "one",
-		Severity:     "error",
+		Severity:     model.SeverityError,
 		RuleCategory: model.RuleCategories[model.CategoryInfo],
 	}, StartNode: &yaml.Node{Line: 1, Column: 10}, EndNode: &yaml.Node{Line: 20, Column: 20}}
 


### PR DESCRIPTION
Big but trivial/mechanic change, just something I ran into while looking into something else, and thought I'd refactor while at it.