### PR TITLE
Disabling auto tagging to merge multiple MRs

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,9 +1,10 @@
 name: Tag Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   tag:


### PR DESCRIPTION
a few changes need to go in together, disabling automation until we're ready to go.