### PR TITLE
Added support for swagger security requirements #154

### DIFF
--- a/functions/openapi/unused_component.go
+++ b/functions/openapi/unused_component.go
@@ -43,6 +43,15 @@ func (uc UnusedComponent) RunRule(nodes []*yaml.Node, context model.RuleFunction
 	links := context.Index.GetAllLinks()
 	callbacks := context.Index.GetAllCallbacks()
 
+	// extract securityRequirements from swagger. These are not mapped as they are not $refs
+	// so, we need to map them as if they were.
+	secReq := context.Index.GetSecurityRequirementReferences()
+	if context.SpecInfo != nil && context.SpecInfo.SpecType == utils.OpenApi2 {
+		for r := range secReq {
+			allRefs[fmt.Sprintf("#/securityDefinitions/%s", r)] = &index.Reference{}
+		}
+	}
+
 	// create poly maps.
 	oneOfRefs := make(map[string]*index.Reference)
 	allOfRefs := make(map[string]*index.Reference)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.1.3
+	github.com/pb33f/libopenapi v0.1.4
 	github.com/pterm/pterm v0.12.47
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/pb33f/libopenapi v0.1.2 h1:DMxQ73KZE4xoRJYlgspk9vmPvL+9iuyAnDsa8yaRvF
 github.com/pb33f/libopenapi v0.1.2/go.mod h1:2YQimTECeYQ/LBmRpr+AFo/aR+DsZ8oucOnFAkjt0hg=
 github.com/pb33f/libopenapi v0.1.3 h1:h4CF2Kf8EPBhy+uACoIgncSuvgYMmWs8yKmJ8WfiTZc=
 github.com/pb33f/libopenapi v0.1.3/go.mod h1:2YQimTECeYQ/LBmRpr+AFo/aR+DsZ8oucOnFAkjt0hg=
+github.com/pb33f/libopenapi v0.1.4 h1:Fn93K5xkC6YuwHUvV+9h7tFLSZy/jWuFvwcooY76yyQ=
+github.com/pb33f/libopenapi v0.1.4/go.mod h1:2YQimTECeYQ/LBmRpr+AFo/aR+DsZ8oucOnFAkjt0hg=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Security requirements in swagger are not considered references, however they are treated as such and are not found by the `unused_component` function. This fix required updating libopenapi to index security requirements, which could then be looked  up by vacuum.

https://github.com/pb33f/libopenapi/commit/0d4e8bf3f880883abb248ea9dacefb3b2e2f8f4e
Signed-off-by: Dave Shanley <dave@quobix.com>