### PR TITLE
(fix): Bugfix for issue #163

### DIFF
--- a/functions/core/truthy.go
+++ b/functions/core/truthy.go
@@ -51,10 +51,16 @@ func (t *Truthy) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 			}
 
 			if !utils.IsNodeMap(fieldNode) && !utils.IsNodeArray(fieldNodeValue) {
+				var endNode *yaml.Node
+				if len(node.Content) > 0 {
+					endNode = node.Content[len(node.Content)-1]
+				} else {
+					endNode = node
+				}
 				results = append(results, model.RuleFunctionResult{
 					Message:   fmt.Sprintf("%s: `%s` must be set", context.Rule.Description, context.RuleAction.Field),
 					StartNode: node,
-					EndNode:   node.Content[len(node.Content)-1],
+					EndNode:   endNode,
 					Path:      pathValue,
 					Rule:      context.Rule,
 				})

--- a/functions/core/truthy_test.go
+++ b/functions/core/truthy_test.go
@@ -103,6 +103,26 @@ tags:
 	assert.Len(t, res, 2)
 }
 
+func TestTruthy_RunRule_NoContent(t *testing.T) {
+
+	sampleYaml := `info: test`
+
+	path := "$.info"
+
+	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
+	assert.Len(t, nodes, 1)
+
+	rule := buildCoreTestRule(path, model.SeverityError, "truthy", "info", nil)
+	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Given = path
+	ctx.Rule = &rule
+
+	tru := Truthy{}
+	res := tru.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 1)
+}
+
 func TestTruthy_RunRule_ArrayTest(t *testing.T) {
 
 	sampleYaml := `- lemons:


### PR DESCRIPTION
The end node cannot be calculated if there is no content supplied (i.e. the wrong object type is passed in).

Signed-off-by: Dave Shanley <dave@quobix.com>