### PR TITLE
(feat): Added ability to pass in `SpecInfo` to avoid re-parsing.

### DIFF
--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -34,6 +34,7 @@ type ruleContext struct {
 type RuleSetExecution struct {
 	RuleSet         *rulesets.RuleSet             // The RuleSet in which to apply
 	Spec            []byte                        // The raw bytes of the OpenAPI specification.
+	SpecInfo        *datamodel.SpecInfo           // Pre-parsed spec-info.
 	CustomFunctions map[string]model.RuleFunction // custom functions loaded from plugin.
 }
 
@@ -68,12 +69,18 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 	var specResolved yaml.Node
 	var specUnresolved yaml.Node
 
-	// extract spec info, make this available to rule context.
-	specInfo, err := datamodel.ExtractSpecInfo(execution.Spec)
-	if err != nil || specInfo == nil {
-		if specInfo == nil || specInfo.RootNode == nil {
-			return &RuleSetExecutionResult{Errors: []error{err}}
+	var specInfo *datamodel.SpecInfo
+	var err error
+	if execution.SpecInfo == nil {
+		// extract spec info, make this available to rule context.
+		specInfo, err = datamodel.ExtractSpecInfo(execution.Spec)
+		if err != nil || specInfo == nil {
+			if specInfo == nil || specInfo.RootNode == nil {
+				return &RuleSetExecutionResult{Errors: []error{err}}
+			}
 		}
+	} else {
+		specInfo = execution.SpecInfo
 	}
 
 	specUnresolved = *specInfo.RootNode


### PR DESCRIPTION
If using vacuum as a library, this feature allows a pre-parsed spec to be supplied, vs. only having the raw bytes (which will internally cause those bytes to be parsed). Useful for tooling consuming another pb33f tool. Non-breaking change.

Signed-off-by: Dave Shanley <dave@quobix.com>