### PR TITLE
feat: Added `--no-style` or `q` flags #234

### DIFF
--- a/cmd/html_report.go
+++ b/cmd/html_report.go
@@ -42,6 +42,15 @@ func GetHTMLReportCommand() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
+
+			// disable color and styling, for CI/CD use.
+			// https://github.com/daveshanley/vacuum/issues/234
+			if noStyleFlag {
+				pterm.DisableColor()
+				pterm.DisableStyling()
+			}
+
 			PrintBanner()
 
 			// check for file args
@@ -127,6 +136,7 @@ func GetHTMLReportCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolP("disableTimestamp", "d", false, "Disable timestamp in report")
+	cmd.Flags().BoolP("no-style", "q", false, "Disable styling and color output, just plain text (useful for CI/CD)")
 
 	return cmd
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -42,6 +42,14 @@ func GetLintCommand() *cobra.Command {
 			silent, _ := cmd.Flags().GetBool("silent")
 			functionsFlag, _ := cmd.Flags().GetString("functions")
 			failSeverityFlag, _ := cmd.Flags().GetString("fail-severity")
+			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
+
+			// disable color and styling, for CI/CD use.
+			// https://github.com/daveshanley/vacuum/issues/234
+			if noStyleFlag {
+				pterm.DisableColor()
+				pterm.DisableStyling()
+			}
 
 			if !silent {
 				PrintBanner()
@@ -186,6 +194,7 @@ func GetLintCommand() *cobra.Command {
 	cmd.Flags().BoolP("errors", "e", false, "Show errors only")
 	cmd.Flags().StringP("category", "c", "", "Show a single category of results")
 	cmd.Flags().BoolP("silent", "x", false, "Show nothing except the result.")
+	cmd.Flags().BoolP("no-style", "q", false, "Disable styling and color output, just plain text (useful for CI/CD)")
 	cmd.Flags().StringP("fail-severity", "n", model.SeverityError, "Results of this level or above will trigger a failure exit code")
 
 	regErr := cmd.RegisterFlagCompletionFunc("category", cobra.FixedCompletions([]string{

--- a/cmd/spectral_report.go
+++ b/cmd/spectral_report.go
@@ -42,6 +42,14 @@ func GetSpectralReportCommand() *cobra.Command {
 
 			stdIn, _ := cmd.Flags().GetBool("stdin")
 			stdOut, _ := cmd.Flags().GetBool("stdout")
+			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
+
+			// disable color and styling, for CI/CD use.
+			// https://github.com/daveshanley/vacuum/issues/234
+			if noStyleFlag {
+				pterm.DisableColor()
+				pterm.DisableStyling()
+			}
 
 			if !stdIn && !stdOut {
 				PrintBanner()
@@ -173,6 +181,7 @@ func GetSpectralReportCommand() *cobra.Command {
 	cmd.Flags().BoolP("stdin", "i", false, "Use stdin as input, instead of a file")
 	cmd.Flags().BoolP("stdout", "o", false, "Use stdout as output, instead of a file")
 	cmd.Flags().BoolP("no-pretty", "n", false, "Render JSON with no formatting")
+	cmd.Flags().BoolP("no-style", "q", false, "Disable styling and color output, just plain text (useful for CI/CD)")
 	return cmd
 
 }

--- a/cmd/vacuum_report.go
+++ b/cmd/vacuum_report.go
@@ -41,6 +41,14 @@ func GetVacuumReportCommand() *cobra.Command {
 
 			stdIn, _ := cmd.Flags().GetBool("stdin")
 			stdOut, _ := cmd.Flags().GetBool("stdout")
+			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
+
+			// disable color and styling, for CI/CD use.
+			// https://github.com/daveshanley/vacuum/issues/234
+			if noStyleFlag {
+				pterm.DisableColor()
+				pterm.DisableStyling()
+			}
 
 			if !stdIn && !stdOut {
 				PrintBanner()
@@ -202,5 +210,6 @@ func GetVacuumReportCommand() *cobra.Command {
 	cmd.Flags().BoolP("stdout", "o", false, "Use stdout as output, instead of a file")
 	cmd.Flags().BoolP("compress", "c", false, "Compress results using gzip")
 	cmd.Flags().BoolP("no-pretty", "n", false, "Render JSON with no formatting")
+	cmd.Flags().BoolP("no-style", "q", false, "Disable styling and color output, just plain text (useful for CI/CD)")
 	return cmd
 }

--- a/functions/openapi/oas2_discriminator.go
+++ b/functions/openapi/oas2_discriminator.go
@@ -29,7 +29,7 @@ func (od OAS2Discriminator) RunRule(nodes []*yaml.Node, context model.RuleFuncti
 
 	var results []model.RuleFunctionResult
 
-	schemas := context.Index.GetAllSchemas()
+	schemas := context.Index.GetAllComponentSchemas()
 
 	for id, schema := range schemas {
 

--- a/functions/openapi/unused_component.go
+++ b/functions/openapi/unused_component.go
@@ -34,7 +34,7 @@ func (uc UnusedComponent) RunRule(nodes []*yaml.Node, context model.RuleFunction
 
 	// extract all references, and every single component
 	allRefs := context.Index.GetAllReferences()
-	schemas := context.Index.GetAllSchemas()
+	schemas := context.Index.GetAllComponentSchemas()
 	responses := context.Index.GetAllResponses()
 	parameters := context.Index.GetAllParameters()
 	examples := context.Index.GetAllExamples()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.4.11
+	github.com/pb33f/libopenapi v0.5.0
 	github.com/pterm/pterm v0.12.51
 	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/pb33f/libopenapi v0.4.10 h1:tP1sOW3TVAimr+mzSbgf01QgTCc2oWnLHqE54/fVc
 github.com/pb33f/libopenapi v0.4.10/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
 github.com/pb33f/libopenapi v0.4.11 h1:Z0CbosqaMDKF/8DBeX1w2kf+uGFmLsSNPImoVWmKNYA=
 github.com/pb33f/libopenapi v0.4.11/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
+github.com/pb33f/libopenapi v0.5.0 h1:fzyif6cppFqfahoGY6lSWLSk7ndmwhUudgjHZTS1Cso=
+github.com/pb33f/libopenapi v0.5.0/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/model/test_files/circular-tests.yaml
+++ b/model/test_files/circular-tests.yaml
@@ -1,3 +1,4 @@
+openapi: 3.0
 paths:
   /burgers:
     post:
@@ -13,13 +14,18 @@ components:
       properties:
         things:
           "$ref": "#/components/schemas/Two"
+      required:
+        - things
     Two:
-      decription: "test two"
+      description: "test two"
       properties:
         testThing:
           "$ref": "#/components/schemas/One"
         anyOf:
           - "$ref": "#/components/schemas/Four"
+      required:
+        - testThing
+        - anyOf
     Three:
       description: "test three"
       properties:
@@ -29,30 +35,40 @@ components:
           "$ref": "#/components/schemas/Seven"
         yester:
           "$ref": "#/components/schemas/Seven"
+      required:
+        - tester
+        - bester
+        - yester
     Four:
-      desription: "test four"
+      description: "test four"
       properties:
         lemons:
           "$ref": "#/components/schemas/Nine"
+      required:
+        - lemons
     Five:
       properties:
         rice:
           "$ref": "#/components/schemas/Six"
+      required:
+        - rice
     Six:
       properties:
         mints:
           "$ref": "#/components/schemas/Nine"
+      required:
+        - mints
     Seven:
       properties:
         wow:
           "$ref": "#/components/schemas/Three"
+      required:
+        - wow
     Nine:
       description: done.
     Ten:
       properties:
         yeah:
           "$ref": "#/components/schemas/Ten"
-
-
-
-
+      required:
+        - yeah


### PR DESCRIPTION
Something that I overlooked, even though I know about this issue - is color in CI/CD. This issue was reported in #234, and it's a major defect in my opinion, so now the `report` `lint` `html-report` commands all accept a `--no-style` or `q` flag to turn of all formatting and styling for the console.

Also upgraded to libopenapi 0.5.0

Signed-off-by: Dave Shanley <dave@quobix.com>