### PR TITLE
fix: check length of *yaml.Node arr

### DIFF
--- a/functions/core/alphabetical.go
+++ b/functions/core/alphabetical.go
@@ -134,14 +134,23 @@ func (a Alphabetical) isValidArray(arr *yaml.Node) bool {
 }
 
 func (a Alphabetical) isValidStringArray(arr *yaml.Node) bool {
+	if len(arr.Content) == 0 {
+		return false
+	}
 	return arr.Content[0].Tag == "!!str"
 }
 
 func (a Alphabetical) isValidNumberArray(arr *yaml.Node) bool {
+	if len(arr.Content) == 0 {
+		return false
+	}
 	return arr.Content[0].Tag == "!!int" || arr.Content[0].Tag == "!!float"
 }
 
 func (a Alphabetical) isValidMapArray(arr *yaml.Node) bool {
+	if len(arr.Content) == 0 {
+		return false
+	}
 	return arr.Content[0].Tag == "!!map"
 }
 


### PR DESCRIPTION
Hi,
We got an error about the following stack trace.

Solution:
In the alphebetical.go file we've added length check the incoming *yaml.Node type array 

```
panic: runtime error: index out of range [0] with length 0

goroutine 664 [running]:
github.com/daveshanley/vacuum/functions/core.Alphabetical.isValidStringArray(...)
	/builds/devx/productivity/api-hub/api-linter/.go/pkg/mod/github.com/daveshanley/vacuum@v0.0.53/functions/core/alphabetical.go:137
github.com/daveshanley/vacuum/functions/core.Alphabetical.RunRule({}, {0xc0000137d0, 0x1, 0xc001aedda0?}, {0xc001ddcd20, 0xc0017f2840, {0x11884e0, 0xc0016b8720}, {0x11f2960, 0xc0016dccc0}, ...})
	/builds/devx/productivity/api-hub/api-linter/.go/pkg/mod/github.com/daveshanley/vacuum@v0.0.53/functions/core/alphabetical.go:79 +0xf25
github.com/daveshanley/vacuum/motor.buildResults({0xc0017f2840, 0xc0011d79a0, {0x15c85f8, 0xc0011a41e0}, 0xc0015a7218, 0xc0017c3f20, 0xc000460bb8, 0xc001aea900, 0xc0011d7a40, 0x0, ...}, ...)
	/builds/devx/productivity/api-hub/api-linter/.go/pkg/mod/github.com/daveshanley/vacuum@v0.0.53/motor/rule_applicator.go:408 +0x61c
github.com/daveshanley/vacuum/motor.runRule({0xc0017f2840, 0xc0011d79a0, {0x15c85f8, 0xc0011a41e0}, 0xc0015a7218, 0xc0017c3f20, 0xc000460bb8, 0xc001aea900, 0xc0011d7a40, 0x0, ...})
	/builds/devx/productivity/api-hub/api-linter/.go/pkg/mod/github.com/daveshanley/vacuum@v0.0.53/motor/rule_applicator.go:333 +0x3af
created by github.com/daveshanley/vacuum/motor.ApplyRulesToRuleSet
	/builds/devx/productivity/api-hub/api-linter/.go/pkg/mod/github.com/daveshanley/vacuum@v0.0.53/motor/rule_applicator.go:167 +0x785
```
@erkanzileli 