### PR TITLE
Bumped to `libopenapi-validator` v0.0.6 #271

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pb33f/libopenapi v0.8.1
-	github.com/pb33f/libopenapi-validator v0.0.5
+	github.com/pb33f/libopenapi-validator v0.0.6
 	github.com/pterm/pterm v0.12.57
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/pb33f/libopenapi-validator v0.0.4 h1:Z5BIRfgcE8JXx8MW1Ffv8+YTMA47y5G5
 github.com/pb33f/libopenapi-validator v0.0.4/go.mod h1:uAF035zrQxpAdaoZuZZyy7eh7+Fjw3ovv4bOAPjt97U=
 github.com/pb33f/libopenapi-validator v0.0.5 h1:NaJMU+51NW54u2ihfCKRt5/Apkll0ERA0Xq6yJSw4UY=
 github.com/pb33f/libopenapi-validator v0.0.5/go.mod h1:uAF035zrQxpAdaoZuZZyy7eh7+Fjw3ovv4bOAPjt97U=
+github.com/pb33f/libopenapi-validator v0.0.6 h1:bO43y6UGLOUQpru0XezUUxPtnoKMKM4WQCSS+xMElxY=
+github.com/pb33f/libopenapi-validator v0.0.6/go.mod h1:uAF035zrQxpAdaoZuZZyy7eh7+Fjw3ovv4bOAPjt97U=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Added a check in `libopenapi-validator` to catch JSON schema issues. Bumped vacuum lib version to consume.