### PR TITLE
Added new `—skip-check` / `-k` flag to allow any document to be linted

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,4 +105,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: dshanley/vacuum:latest
+          tags: dshanley/vacuum:latest, dshanley/vacuum:${{ github.event.client_payload.new-tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 RUN mkdir -p /opt/vacuum
 
@@ -7,9 +7,9 @@ WORKDIR /opt/vacuum
 COPY . ./
 
 RUN go mod download && go mod verify
-RUN go build -v -o /vacuum vacuum.go
+RUN go build -ldflags="-w -s" -v -o /vacuum vacuum.go
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 WORKDIR /work
 COPY --from=0 /vacuum /
 

--- a/cmd/build_results.go
+++ b/cmd/build_results.go
@@ -13,6 +13,15 @@ func BuildResults(
 	specBytes []byte,
 	customFunctions map[string]model.RuleFunction,
 	base string) (*model.RuleResultSet, *motor.RuleSetExecutionResult, error) {
+	return BuildResultsWithDocCheckSkip(rulesetFlag, specBytes, customFunctions, base, false)
+}
+
+func BuildResultsWithDocCheckSkip(
+	rulesetFlag string,
+	specBytes []byte,
+	customFunctions map[string]model.RuleFunction,
+	base string,
+	skipCheck bool) (*model.RuleResultSet, *motor.RuleSetExecutionResult, error) {
 
 	// read spec and parse
 	defaultRuleSets := rulesets.BuildDefaultRuleSets()
@@ -37,10 +46,11 @@ func BuildResults(
 	pterm.Info.Printf("Linting against %d rules: %s\n", len(selectedRS.Rules), selectedRS.DocumentationURI)
 
 	ruleset := motor.ApplyRulesToRuleSet(&motor.RuleSetExecution{
-		RuleSet:         selectedRS,
-		Spec:            specBytes,
-		CustomFunctions: customFunctions,
-		Base:            base,
+		RuleSet:           selectedRS,
+		Spec:              specBytes,
+		CustomFunctions:   customFunctions,
+		Base:              base,
+		SkipDocumentCheck: skipCheck,
 	})
 
 	resultSet := model.NewRuleResultSet(ruleset.Results)

--- a/cmd/build_results_test.go
+++ b/cmd/build_results_test.go
@@ -9,3 +9,8 @@ func TestBuildResults(t *testing.T) {
 	_, _, err := BuildResults("nuggets", nil, nil, "")
 	assert.Error(t, err)
 }
+
+func TestBuildResults_SkipCheck(t *testing.T) {
+	_, _, err := BuildResultsWithDocCheckSkip("nuggets", nil, nil, "", true)
+	assert.Error(t, err)
+}

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -41,6 +41,7 @@ func GetDashboardCommand() *cobra.Command {
 				return errors.New(errText)
 			}
 			baseFlag, _ := cmd.Flags().GetString("base")
+			skipCheckFlag, _ := cmd.Flags().GetBool("skip-check")
 
 			var err error
 			vacuumReport, specBytes, _ := vacuum_report.BuildVacuumReportFromFile(args[0])
@@ -61,7 +62,7 @@ func GetDashboardCommand() *cobra.Command {
 				customFunctions, _ := LoadCustomFunctions(functionsFlag)
 
 				rulesetFlag, _ := cmd.Flags().GetString("ruleset")
-				resultSet, ruleset, err = BuildResults(rulesetFlag, specBytes, customFunctions, baseFlag)
+				resultSet, ruleset, err = BuildResultsWithDocCheckSkip(rulesetFlag, specBytes, customFunctions, baseFlag, skipCheckFlag)
 				if err != nil {
 					pterm.Error.Printf("Failed to render dashboard: %v\n\n", err)
 					return err

--- a/cmd/html_report.go
+++ b/cmd/html_report.go
@@ -44,6 +44,7 @@ func GetHTMLReportCommand() *cobra.Command {
 
 			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
 			baseFlag, _ := cmd.Flags().GetString("base")
+			skipCheckFlag, _ := cmd.Flags().GetBool("skip-check")
 
 			// disable color and styling, for CI/CD use.
 			// https://github.com/daveshanley/vacuum/issues/234
@@ -92,7 +93,7 @@ func GetHTMLReportCommand() *cobra.Command {
 				customFunctions, _ := LoadCustomFunctions(functionsFlag)
 
 				rulesetFlag, _ := cmd.Flags().GetString("ruleset")
-				resultSet, ruleset, err = BuildResults(rulesetFlag, specBytes, customFunctions, baseFlag)
+				resultSet, ruleset, err = BuildResultsWithDocCheckSkip(rulesetFlag, specBytes, customFunctions, baseFlag, skipCheckFlag)
 				if err != nil {
 					pterm.Error.Printf("Failed to generate report: %v\n\n", err)
 					return err

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -44,6 +44,7 @@ func GetLintCommand() *cobra.Command {
 			failSeverityFlag, _ := cmd.Flags().GetString("fail-severity")
 			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
 			baseFlag, _ := cmd.Flags().GetString("base")
+			skipCheckFlag, _ := cmd.Flags().GetBool("skip-check")
 
 			// disable color and styling, for CI/CD use.
 			// https://github.com/daveshanley/vacuum/issues/234
@@ -104,10 +105,11 @@ func GetLintCommand() *cobra.Command {
 			pterm.Info.Printf("Linting against %d rules: %s\n", len(selectedRS.Rules), selectedRS.DocumentationURI)
 			start := time.Now()
 			result := motor.ApplyRulesToRuleSet(&motor.RuleSetExecution{
-				RuleSet:         selectedRS,
-				Spec:            specBytes,
-				CustomFunctions: customFunctions,
-				Base:            baseFlag,
+				RuleSet:           selectedRS,
+				Spec:              specBytes,
+				CustomFunctions:   customFunctions,
+				Base:              baseFlag,
+				SkipDocumentCheck: skipCheckFlag,
 			})
 
 			results := result.Results

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("ruleset", "r", "", "Path to a spectral ruleset configuration")
 	rootCmd.PersistentFlags().StringP("functions", "f", "", "Path to custom functions")
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Base URL or path to use for resolving relative or remote references")
+	rootCmd.PersistentFlags().BoolP("skip-check", "k", false, "Skip checking for a valid OpenAPI document, useful for linting fragments or non-OpenAPI documents")
 
 	regErr := rootCmd.RegisterFlagCompletionFunc("functions", cobra.FixedCompletions(
 		[]string{"so"}, cobra.ShellCompDirectiveFilterFileExt,

--- a/cmd/spectral_report.go
+++ b/cmd/spectral_report.go
@@ -44,6 +44,7 @@ func GetSpectralReportCommand() *cobra.Command {
 			stdOut, _ := cmd.Flags().GetBool("stdout")
 			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
 			baseFlag, _ := cmd.Flags().GetString("base")
+			skipCheckFlag, _ := cmd.Flags().GetBool("skip-check")
 
 			// disable color and styling, for CI/CD use.
 			// https://github.com/daveshanley/vacuum/issues/234
@@ -130,11 +131,12 @@ func GetSpectralReportCommand() *cobra.Command {
 			}
 
 			ruleset := motor.ApplyRulesToRuleSet(&motor.RuleSetExecution{
-				RuleSet:         selectedRS,
-				Spec:            specBytes,
-				CustomFunctions: customFunctions,
-				SilenceLogs:     true,
-				Base:            baseFlag,
+				RuleSet:           selectedRS,
+				Spec:              specBytes,
+				CustomFunctions:   customFunctions,
+				SilenceLogs:       true,
+				Base:              baseFlag,
+				SkipDocumentCheck: skipCheckFlag,
 			})
 
 			resultSet := model.NewRuleResultSet(ruleset.Results)

--- a/cmd/vacuum_report.go
+++ b/cmd/vacuum_report.go
@@ -44,6 +44,7 @@ func GetVacuumReportCommand() *cobra.Command {
 			noStyleFlag, _ := cmd.Flags().GetBool("no-style")
 			baseFlag, _ := cmd.Flags().GetString("base")
 			junitFlag, _ := cmd.Flags().GetBool("junit")
+			skipCheckFlag, _ := cmd.Flags().GetBool("skip-check")
 
 			// disable color and styling, for CI/CD use.
 			// https://github.com/daveshanley/vacuum/issues/234
@@ -132,11 +133,12 @@ func GetVacuumReportCommand() *cobra.Command {
 			}
 
 			ruleset := motor.ApplyRulesToRuleSet(&motor.RuleSetExecution{
-				RuleSet:         selectedRS,
-				Spec:            specBytes,
-				CustomFunctions: customFunctions,
-				SilenceLogs:     true,
-				Base:            baseFlag,
+				RuleSet:           selectedRS,
+				Spec:              specBytes,
+				CustomFunctions:   customFunctions,
+				SilenceLogs:       true,
+				Base:              baseFlag,
+				SkipDocumentCheck: skipCheckFlag,
 			})
 
 			resultSet := model.NewRuleResultSet(ruleset.Results)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.9.5
+	github.com/pb33f/libopenapi v0.9.6
 	github.com/pb33f/libopenapi-validator v0.0.10
 	github.com/pterm/pterm v0.12.62
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.9.5 h1:4Z4zPPk53i46PH6EPnKc/ieiMPY7Qa5RDAKUOXYDYUU=
-github.com/pb33f/libopenapi v0.9.5/go.mod h1:8lr9sjsI5uZxtiEvHgg1A9/p/70briQ5WUGoJiuTFPc=
+github.com/pb33f/libopenapi v0.9.6 h1:PqNqdBk0lqr/luxDLv8HPKFEJ4i0zf/hpyXqQ4r8jbM=
+github.com/pb33f/libopenapi v0.9.6/go.mod h1:8lr9sjsI5uZxtiEvHgg1A9/p/70briQ5WUGoJiuTFPc=
 github.com/pb33f/libopenapi-validator v0.0.10 h1:+8WE5TPJ35ptp0FoiurRy0gPq9/BoezSBUgk140xZNQ=
 github.com/pb33f/libopenapi-validator v0.0.10/go.mod h1:NjY6ZsalzzcenfYJe9NFB4Hy9DKWjM/7DTnf4MF+n/M=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/model/test_files/non-openapi.yaml
+++ b/model/test_files/non-openapi.yaml
@@ -1,0 +1,20 @@
+_format_version: "3.0"
+services:
+  - host: mockbin.org
+    id: b1525aee-d304-11ed-afa1-0242ac120002
+    name: summer-time
+    path: /requests
+    plugins: []
+    port: 443
+    protocol: https
+    routes:
+      - id: b7d87736-d304-11ed-afa1-0242ac120002
+        methods:
+          - GET
+        name: summer-time_get
+        paths:
+          - ~/summer-time$
+        plugins: []
+        regex_priority: 200
+        strip_path: false
+        tags: []

--- a/motor/rule_applicator_test.go
+++ b/motor/rule_applicator_test.go
@@ -1756,6 +1756,7 @@ func TestApplyRules_TestRules_Custom_Document_Pattern(t *testing.T) {
 
 	random, err := os.ReadFile("../model/test_files/non-openapi.yaml")
 
+	assert.NoError(t, err)
 	// create a new document.
 	docConfig := datamodel.NewClosedDocumentConfiguration()
 	docConfig.BypassDocumentCheck = true

--- a/motor/rule_composer.go
+++ b/motor/rule_composer.go
@@ -20,7 +20,7 @@ func CreateRuleComposer() *RuleComposer {
 
 // ComposeRuleSet compose a byte array ruleset specification into a *model.RuleSet
 func (rc *RuleComposer) ComposeRuleSet(ruleset []byte) (*rulesets.RuleSet, error) {
-	rs, err := rulesets.CreateRuleSetUsingJSON(ruleset)
+	rs, err := rulesets.CreateRuleSetFromData(ruleset)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now any YAML or JSON file can be linted. Core functions can be used for any file directly, not just OpenAPI documents.

For example, with a ruleset with a custom rule:

```yaml
rules:
  my-new-rule:
    description: "Check the version is correct."
    given: $._format_version
    severity: error
    then:
      function: pattern
      functionOptions:
        match: "^1.1$"
```

and a custom yaml file:

```yaml
_format_version: "3.0"
services:
  - host: mockbin.org
    id: b1525aee-d304-11ed-afa1-0242ac120002
    name: summer-time
    path: /requests
    plugins: []
    port: 443
    protocol: https
    routes:
      - id: b7d87736-d304-11ed-afa1-0242ac120002
        methods:
          - GET
        name: summer-time_get
        paths:
          - ~/summer-time$
        plugins: []
        regex_priority: 200
        strip_path: false
        tags: []
```

vacuum will now return an error when running any command.

```
Line / Column | Severity | Message                                                                   | Rule        | Path
(1:18)        | error    | Check the version is correct: `3.0` does not match the expression `^1.1$` | my-new-rule | $._format_version['3.0']
```

This new feature allows vacuum to operate a generic linter.
