### PR TITLE
Added docker entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ RUN go mod download && go mod verify
 RUN go build -ldflags="-w -s" -v -o /vacuum vacuum.go
 
 FROM debian:bookworm-slim
+
 WORKDIR /work
-COPY --from=0 /vacuum /
 
-ENV PATH=$PATH:/
+COPY --from=0 /vacuum /usr/local/bin/vacuum
 
-ENTRYPOINT ["vacuum"]
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 # otherwise check if command is a valid vacuum subcommand.
 # If it is, prepend `vacuum` to script parameters:
 # if `$@` is `lint`, it becomes `vacuum lint`
-if [ "${1#-}" != "$1" ] || vacuum "$1" --help > /dev/null 2>&1; then
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
     set -- vacuum "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# If supplied command starts with `-`, we assume it is a flag for vacuum,
+# otherwise check if command is a valid vacuum subcommand.
+# If it is, prepend `vacuum` to script parameters:
+# if `$@` is `lint`, it becomes `vacuum lint`
+if [ "${1#-}" != "$1" ] || vacuum "$1" --help > /dev/null 2>&1; then
+    set -- vacuum "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Add entrypoint script that allows running programs other than vacuum inside of container.

Now container can be used in this ways:
1. `docker run dshanley/vacuum <arguments>` - run vacuum with supplied arguments
2. `docker run dshanley/vacuum vacuum <arguments>` - the same as 1
3. `docker run dshanley/vacuum <cmd>` - run arbitrary command in container

This change should be useful in some CIs. Gitlab CI, for example, starts bash inside of container and sends script to its stdin. Previous image didn't work in Gitlab CI, because bash couldn't be started.

Inspiration for this script was taken from https://github.com/traefik/traefik-library-image/blob/d9507badace6c064417d852daeea402d29ec0707/alpine/Dockerfile