### PR TITLE
Fixed a small issue with detecting multi examples.

### DIFF
--- a/functions/functions_test.go
+++ b/functions/functions_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestMapBuiltinFunctions(t *testing.T) {
 	funcs := MapBuiltinFunctions()
-	assert.Len(t, funcs.GetAllFunctions(), 45)
+	assert.Len(t, funcs.GetAllFunctions(), 46)
 }

--- a/functions/openapi/examples.go
+++ b/functions/openapi/examples.go
@@ -244,6 +244,7 @@ func checkDefinitionForExample(componentNode *yaml.Node, compName string,
 
 				// check for an example
 				exKey, exValue := utils.FindKeyNode("example", prop.Content)
+				examplesKey, examplesValue := utils.FindKeyNodeTop("examples", prop.Content)
 				_, typeValue := utils.FindKeyNode("type", prop.Content)
 				_, enumValue := utils.FindKeyNode("enum", prop.Content)
 
@@ -262,7 +263,7 @@ func checkDefinitionForExample(componentNode *yaml.Node, compName string,
 					continue
 				}
 
-				if exKey == nil && exValue == nil && !skip {
+				if examplesKey == nil && examplesValue == nil && exKey == nil && exValue == nil && !skip {
 
 					res := model.BuildFunctionResultString(fmt.Sprintf("Missing example for `%s` on component `%s`",
 						pName, compName))


### PR DESCRIPTION
`examples` at the top level of a schema were being missed and the function was throwing some false positives during development of a new specification.