### PR TITLE
Bugfix finding global security in `owasp.CheckSecurity`

### DIFF
--- a/functions/owasp/check_security.go
+++ b/functions/owasp/check_security.go
@@ -46,16 +46,13 @@ func (cd CheckSecurity) RunRule(nodes []*yaml.Node, context model.RuleFunctionCo
 
 	for i := 1; i < len(valueOfPathNode.Content); i += 2 {
 		for j := 0; j < len(valueOfPathNode.Content[i].Content); j += 2 {
-			if slices.Contains([]string{
-				"get",
-				"head",
-				"post",
-				"put",
-				"patch",
-				"delete",
-				"options",
-				"trace",
-			}, valueOfPathNode.Content[i].Content[j].Value) && slices.Contains(methods, valueOfPathNode.Content[i].Content[j].Value) && len(valueOfPathNode.Content[i].Content) > j+1 {
+			if slices.Contains(
+				[]string{"get", "head", "post", "put", "patch", "delete", "options", "trace"},
+				valueOfPathNode.Content[i].Content[j].Value,
+			) && slices.Contains(
+				methods,
+				valueOfPathNode.Content[i].Content[j].Value,
+			) && len(valueOfPathNode.Content[i].Content) > j+1 {
 				operation := valueOfPathNode.Content[i].Content[j+1]
 				results = append(results, checkSecurityRule(operation, valueOfSecurityGlobalNode, nullable, valueOfPathNode.Content[i-1].Value, valueOfPathNode.Content[i].Content[j].Value, context)...)
 			}

--- a/functions/owasp/check_security_test.go
+++ b/functions/owasp/check_security_test.go
@@ -53,3 +53,34 @@ components:
 	assert.Len(t, res, 2)
 
 }
+
+func TestCheckSecurity_SecurityMissingOnOneOperation(t *testing.T) {
+	test_appspec := `openapi: 3.0.1
+info:
+  version: "1.2.3"
+  title: "securitySchemes"
+paths:
+  /insecure:
+    put:
+      responses: {}
+  /secure:
+    put:
+      responses: {}
+      security:
+        - BasicAuth: []
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic`
+
+	path := "$"
+	nodes, _ := utils.FindNodes([]byte(test_appspec), path)
+	rule := buildOpenApiTestRuleAction(path, "check_security", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), map[string]interface{}{
+		"methods": []string{"put"},
+	})
+	ruleFunctionResults := CheckSecurity{}.RunRule(nodes, ctx)
+
+	assert.Len(t, ruleFunctionResults, 1)
+}


### PR DESCRIPTION
This PR fixes `owasp.CheckSecurity`'s `RunRule` method's logic for finding the global security in an OpenAPI schema.

Previously `utils.FindFirstKeyNode` was used, from [github.com/pb33f/libopenapi/utils](https://pkg.go.dev/github.com/pb33f/libopenapi@v0.9.7/utils), however this is recursive so would find the first security node at any depth - including security definitions on individual operations. So, if there was no global security then the security of the first operation traversed was used in lieu. 

For example, in the following appspec, the security on the `PUT /secure` operation was mistakenly extracted as the global security:

```yaml
openapi: 3.0.1
info:
  version: "1.2.3"
  title: "securitySchemes"
paths:
  /insecure:
    put:
      responses: {}
  /secure:
    put:
      responses: {}
      security:
        - BasicAuth: []
components:
  securitySchemes:
    BasicAuth:
      type: http
      scheme: basic
```

As a result, none of the following rules would generate results for the `PUT /insecure` operation:
 - [owasp-protection-global-safe](https://quobix.com/vacuum/rules/owasp/owasp-protection-global-safe/)
 - [owasp-protection-global-unsafe](https://quobix.com/vacuum/rules/owasp/owasp-protection-global-unsafe/)
 - [owasp-protection-global-unsafe-strict](https://quobix.com/vacuum/rules/owasp/owasp-protection-global-unsafe-strict/)

A test has been added in 0d7ddbd1667084c4a1713b02645f04ce05bb4439 with the above appspec and the underlying issue addressed by traversing the `*yaml.Node`s appropriately in a helper func `findGlobalSecurityNode` in 3938a712f88e2282b44e7d1068ce71d793adf730.

In the process of debugging I also reformatted a difficult to read expression in 20cb2646f977e7ce25ca77900c934f33591a8bf3.

Closes https://github.com/daveshanley/vacuum/issues/340.