### PR TITLE
Upgraded to latest dependencies in `libopenapi` and `libopenapi_validator`

### DIFF
--- a/functions/core/schema.go
+++ b/functions/core/schema.go
@@ -86,6 +86,7 @@ func (sch Schema) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext)
 	// use the current node to validate (field not needed)
 	forceValidationOnCurrentNode := utils.ExtractValueFromInterfaceMap("forceValidationOnCurrentNode", context.Options)
 	if _, ok := forceValidationOnCurrentNode.(bool); ok && len(nodes) > 0 {
+		schema.GoLow().Index = context.Index
 		results = append(results, validateNodeAgainstSchema(schema, nodes[0], context, 0)...)
 		return results
 	}
@@ -105,6 +106,7 @@ func (sch Schema) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext)
 
 		_, field := utils.FindKeyNodeTop(context.RuleAction.Field, no)
 		if field != nil {
+			schema.GoLow().Index = context.Index
 			results = append(results, validateNodeAgainstSchema(schema, field, context, x)...)
 
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.10.6
-	github.com/pb33f/libopenapi-validator v0.0.20
+	github.com/pb33f/libopenapi v0.12.1
+	github.com/pb33f/libopenapi-validator v0.0.22
 	github.com/pterm/pterm v0.12.62
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -241,10 +241,10 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.10.6 h1:46iGQqoMm6o5gYK34ER/dpxsSYdh0+76U3+obm5uEyk=
-github.com/pb33f/libopenapi v0.10.6/go.mod h1:s8uj6S0DjWrwZVj20ianJBz+MMjHAbeeRYNyo9ird74=
-github.com/pb33f/libopenapi-validator v0.0.20 h1:ZUrVH/zlam+wWgR2HKuZc0uOuGXvcL3cB8jutPtiI9A=
-github.com/pb33f/libopenapi-validator v0.0.20/go.mod h1:i7j2T/x7W8nJedxXWj7tFdxwp6e6MC2pBIFuJ1AEihg=
+github.com/pb33f/libopenapi v0.12.1 h1:DRhgbg1t32OSYoHT/Bk3stVruqquAkKj+S+OqOQIbBc=
+github.com/pb33f/libopenapi v0.12.1/go.mod h1:s8uj6S0DjWrwZVj20ianJBz+MMjHAbeeRYNyo9ird74=
+github.com/pb33f/libopenapi-validator v0.0.22 h1:2dhrR2OLIrgmMvGnijEw2O+NJ14yw4Wt90HD3ApwSRM=
+github.com/pb33f/libopenapi-validator v0.0.22/go.mod h1:avmxYRGg0u9b+fNWIsOUjujimLfbdzh2vfAsh8zo6V4=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -159,11 +159,12 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 		}
 		specInfoUnresolved, _ = datamodel.ExtractSpecInfoWithDocumentCheck(spec, execution.SkipDocumentCheck)
 	}
-
 	specUnresolved = specInfoUnresolved.RootNode
 	specResolved = specInfo.RootNode
 
 	var indexResolved, indexUnresolved *index.SpecIndex
+
+	config.SpecInfo = specInfo
 
 	// create resolved and un-resolved indexes.
 	if modelIndex != nil {

--- a/motor/rule_tests/openapi_rule_test.go
+++ b/motor/rule_tests/openapi_rule_test.go
@@ -72,7 +72,7 @@ paths:
 	rules := rs.GenerateOpenAPIDefaultRuleSet()
 	lintExecution := motor.ApplyRulesToRuleSet(&motor.RuleSetExecution{RuleSet: rules, Spec: []byte(badDoc)})
 	assert.Len(t, lintExecution.Errors, 0)
-	assert.GreaterOrEqual(t, len(lintExecution.Results), 69)
+	assert.GreaterOrEqual(t, len(lintExecution.Results), 53)
 
 	for n := 0; n < len(lintExecution.Results); n++ {
 		assert.NotNil(t, lintExecution.Results[n].Path)


### PR DESCRIPTION
Less noise in `libopenapi-validator` now, reduced errors in schema violations.

Some breaking changes required an upgrade.