### PR TITLE
Extracted circular referenences back out

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -49,6 +49,7 @@ func GetLintCommand() *cobra.Command {
 			baseFlag, _ := cmd.Flags().GetString("base")
 			skipCheckFlag, _ := cmd.Flags().GetBool("skip-check")
 			remoteFlag, _ := cmd.Flags().GetBool("remote")
+			debugFlag, _ := cmd.Flags().GetBool("debug")
 
 			// disable color and styling, for CI/CD use.
 			// https://github.com/daveshanley/vacuum/issues/234
@@ -75,11 +76,16 @@ func GetLintCommand() *cobra.Command {
 				mf = true
 			}
 
+			logLevel := pterm.LogLevelError
+			if debugFlag {
+				logLevel = pterm.LogLevelDebug
+			}
+
 			// setup logging
 			handler := pterm.NewSlogHandler(&pterm.Logger{
 				Formatter: pterm.LogFormatterColorful,
 				Writer:    os.Stdout,
-				Level:     pterm.LogLevelError,
+				Level:     logLevel,
 				ShowTime:  false,
 				MaxWidth:  280,
 				KeyStyles: map[string]pterm.Style{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Override Base URL or path to use for resolving local file based or remote references")
 	rootCmd.PersistentFlags().BoolP("remote", "u", true, "Allow local files and remote (http) references to be looked up")
 	rootCmd.PersistentFlags().BoolP("skip-check", "k", false, "Skip checking for a valid OpenAPI document, useful for linting fragments or non-OpenAPI documents")
+	rootCmd.PersistentFlags().BoolP("debug", "w", false, "Turn on debug logging")
 
 	regErr := rootCmd.RegisterFlagCompletionFunc("functions", cobra.FixedCompletions(
 		[]string{"so"}, cobra.ShellCompDirectiveFilterFileExt,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.13.19
+	github.com/pb33f/libopenapi v0.13.20
 	github.com/pb33f/libopenapi-validator v0.0.32
 	github.com/pterm/pterm v0.12.71
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.13.19 h1:oFkaQuKx5ZaLwYuHv4W2QeDb+Pm4SU4xqgQdcy2XH58=
-github.com/pb33f/libopenapi v0.13.19/go.mod h1:Lv2eEtsAtbRFlF8hjH82L8SIGoUNgemMVoKoB6A9THk=
+github.com/pb33f/libopenapi v0.13.20 h1:u07mWNSL30sO8nj+kRjM9mDcqxOxq+Etso/oUFflvU4=
+github.com/pb33f/libopenapi v0.13.20/go.mod h1:Lv2eEtsAtbRFlF8hjH82L8SIGoUNgemMVoKoB6A9THk=
 github.com/pb33f/libopenapi-validator v0.0.32 h1:jM+IsUT8I0JOtdkgacGVQmTJayQ2AO5P6URI2HxN11g=
 github.com/pb33f/libopenapi-validator v0.0.32/go.mod h1:1HbsnP1IVFEaLFtbK9eZXRqUpvtQEGmdstqbgMG+72A=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=

--- a/model/test_files/circular-tests.yaml
+++ b/model/test_files/circular-tests.yaml
@@ -21,8 +21,8 @@ components:
       properties:
         testThing:
           "$ref": "#/components/schemas/One"
-        anyOf:
-          - "$ref": "#/components/schemas/Four"
+      anyOf:
+        - "$ref": "#/components/schemas/Four"
       required:
         - testThing
         - anyOf

--- a/motor/rule_applicator_test.go
+++ b/motor/rule_applicator_test.go
@@ -1882,7 +1882,7 @@ components:
 	assert.Len(t, results.Errors, 0)
 
 	assert.NotNil(t, results)
-	assert.Equal(t, "infinite circular reference detected: one: one -> two -> one [14:7]",
+	assert.Equal(t, "infinite circular reference detected: #/components/schemas/one: one -> two -> one [14:7]",
 		results.Results[0].Message)
 	assert.Equal(t, "resolving-references", results.Results[0].RuleId)
 }


### PR DESCRIPTION
Just general better handling of circular references from libopenapi

Also added a `debug` flag to allow log debugging to be turned on for the `lint` command.