### PR TITLE
Allow lookups to be performed correctly with dashboard and reports.

### DIFF
--- a/cmd/build_results.go
+++ b/cmd/build_results.go
@@ -51,6 +51,7 @@ func BuildResultsWithDocCheckSkip(
 		CustomFunctions:   customFunctions,
 		Base:              base,
 		SkipDocumentCheck: skipCheck,
+		AllowLookup:       true,
 	})
 
 	resultSet := model.NewRuleResultSet(ruleset.Results)


### PR DESCRIPTION
make sure non-linting commands can look things up correctly.