### PR TITLE
v0.6.0 Adds support for distributed rulesets. 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(GetHTMLReportCommand())
 	rootCmd.AddCommand(GetDashboardCommand())
 	rootCmd.AddCommand(GetGenerateRulesetCommand())
+	rootCmd.AddCommand(GetGenerateVersionCommand())
 	return rootCmd
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Dave Shanley / Quobix
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+func GetGenerateVersionCommand() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Prints the current version of vacuum",
+		Long:    "Prints out the current version of vacuum to the terminal",
+		Example: "vacuum version",
+		Run: func(cmd *cobra.Command, args []string) {
+			pterm.Println(Version)
+		},
+	}
+	return cmd
+}

--- a/functions/core/alphabetical.go
+++ b/functions/core/alphabetical.go
@@ -4,13 +4,13 @@
 package core
 
 import (
-    "fmt"
-    "github.com/daveshanley/vacuum/model"
-    "github.com/pb33f/libopenapi/utils"
-    "gopkg.in/yaml.v3"
-    "sort"
-    "strconv"
-    "strings"
+	"fmt"
+	"github.com/daveshanley/vacuum/model"
+	"github.com/pb33f/libopenapi/utils"
+	"gopkg.in/yaml.v3"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 // Alphabetical is a rule that will check an array or object to determine if the values are in order.
@@ -20,231 +20,231 @@ type Alphabetical struct{}
 
 // GetSchema returns a model.RuleFunctionSchema defining the schema of the Alphabetical rule.
 func (a Alphabetical) GetSchema() model.RuleFunctionSchema {
-    return model.RuleFunctionSchema{
-        Name: "alphabetical",
-        Properties: []model.RuleFunctionProperty{
-            {
-                Name:        "keyedBy",
-                Description: "this is the key of an object you want to use to sort objects",
-            },
-        },
-        ErrorMessage: "'alphabetical' function has invalid options supplied. To sort objects use 'keyedBy'" +
-            "and decide which property on the array of objects you want to use.",
-    }
+	return model.RuleFunctionSchema{
+		Name: "alphabetical",
+		Properties: []model.RuleFunctionProperty{
+			{
+				Name:        "keyedBy",
+				Description: "this is the key of an object you want to use to sort objects",
+			},
+		},
+		ErrorMessage: "'alphabetical' function has invalid options supplied. To sort objects use 'keyedBy'" +
+			"and decide which property on the array of objects you want to use.",
+	}
 }
 
 // RunRule will execute the Alphabetical rule, based on supplied context and a supplied []*yaml.Node slice.
 func (a Alphabetical) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) []model.RuleFunctionResult {
-    var results []model.RuleFunctionResult
-    if len(nodes) <= 0 {
-        return nil
-    }
+	var results []model.RuleFunctionResult
+	if len(nodes) <= 0 {
+		return nil
+	}
 
-    var keyedBy string
+	var keyedBy string
 
-    // extract a custom message
-    message := context.Rule.Message
+	// extract a custom message
+	message := context.Rule.Message
 
-    // check supplied type
-    props := utils.ConvertInterfaceIntoStringMap(context.Options)
-    if props["keyedBy"] != "" {
-        keyedBy = props["keyedBy"]
-    }
+	// check supplied type
+	props := utils.ConvertInterfaceIntoStringMap(context.Options)
+	if props["keyedBy"] != "" {
+		keyedBy = props["keyedBy"]
+	}
 
-    for _, node := range nodes {
-        pathValue := "unknown"
-        if path, ok := context.Given.(string); ok {
-            pathValue = path
-        }
+	for _, node := range nodes {
+		pathValue := "unknown"
+		if path, ok := context.Given.(string); ok {
+			pathValue = path
+		}
 
-        if utils.IsNodeMap(node) {
+		if utils.IsNodeMap(node) {
 
-            if keyedBy == "" {
-                results = append(results, model.RuleFunctionResult{
-                    Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` is a map/object. %s", context.Rule.Description,
-                        node.Value, a.GetSchema().ErrorMessage)),
-                    StartNode: node,
-                    EndNode:   node,
-                    Path:      pathValue,
-                    Rule:      context.Rule,
-                })
-                continue
-            }
+			if keyedBy == "" {
+				results = append(results, model.RuleFunctionResult{
+					Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` is a map/object. %s", context.Rule.Description,
+						node.Value, a.GetSchema().ErrorMessage)),
+					StartNode: node,
+					EndNode:   node,
+					Path:      pathValue,
+					Rule:      context.Rule,
+				})
+				continue
+			}
 
-            resultsFromKey := a.processMap(node, keyedBy, context)
-            results = compareStringArray(resultsFromKey, context)
-            results = model.MapPathAndNodesToResults(pathValue, node, node, results)
-            continue
-        }
+			resultsFromKey := a.processMap(node, keyedBy, context)
+			results = compareStringArray(resultsFromKey, context)
+			results = model.MapPathAndNodesToResults(pathValue, node, node, results)
+			continue
+		}
 
-        if utils.IsNodeArray(node) {
-            if a.isValidArray(node) {
-                if a.isValidStringArray(node) {
-                    rs := a.checkStringArrayIsSorted(node, context)
-                    results = append(results, rs...)
-                }
+		if utils.IsNodeArray(node) {
+			if a.isValidArray(node) {
+				if a.isValidStringArray(node) {
+					rs := a.checkStringArrayIsSorted(node, context)
+					results = append(results, rs...)
+				}
 
-                if a.isValidNumberArray(node) {
-                    rs := a.checkNumberArrayIsSorted(node, context)
-                    results = append(results, rs...)
-                }
+				if a.isValidNumberArray(node) {
+					rs := a.checkNumberArrayIsSorted(node, context)
+					results = append(results, rs...)
+				}
 
-                if a.isValidMapArray(node) {
-                    resultsFromKey := a.processMap(node, keyedBy, context)
-                    results = compareStringArray(resultsFromKey, context)
-                }
-                results = model.MapPathAndNodesToResults(pathValue, node, node, results)
+				if a.isValidMapArray(node) {
+					resultsFromKey := a.processMap(node, keyedBy, context)
+					results = compareStringArray(resultsFromKey, context)
+				}
+				results = model.MapPathAndNodesToResults(pathValue, node, node, results)
 
-            }
-            continue
-        }
+			}
+			continue
+		}
 
-        // TODO: handle single value code
+		// TODO: handle single value code
 
-    }
+	}
 
-    return results
+	return results
 }
 
 func (a Alphabetical) processMap(node *yaml.Node, keyedBy string, context model.RuleFunctionContext) []string {
-    var resultsFromKey []string
-    for x, v := range node.Content {
-        // run odd numbers for values.
-        if x == 0 || x%2 != 0 {
-            if v.Tag == "!!map" {
+	var resultsFromKey []string
+	for x, v := range node.Content {
+		// run odd numbers for values.
+		if x == 0 || x%2 != 0 {
+			if v.Tag == "!!map" {
 
-                for y, kv := range v.Content {
+				for y, kv := range v.Content {
 
-                    // check keys for keyedBy match
-                    if y%2 == 0 && keyedBy == kv.Value && y+1 < len(v.Content) {
-                        resultsFromKey = append(resultsFromKey, v.Content[y+1].Value)
-                    }
-                }
-            }
-        }
-    }
-    return resultsFromKey
+					// check keys for keyedBy match
+					if y%2 == 0 && keyedBy == kv.Value && y+1 < len(v.Content) {
+						resultsFromKey = append(resultsFromKey, v.Content[y+1].Value)
+					}
+				}
+			}
+		}
+	}
+	return resultsFromKey
 }
 
 func (a Alphabetical) isValidArray(arr *yaml.Node) bool {
-    for _, n := range arr.Content {
-        switch n.Tag {
-        case "!!bool":
-            return false
-        }
-    }
-    return true
+	for _, n := range arr.Content {
+		switch n.Tag {
+		case "!!bool":
+			return false
+		}
+	}
+	return true
 }
 
 func (a Alphabetical) isValidStringArray(arr *yaml.Node) bool {
-    if len(arr.Content) == 0 {
-        return false
-    }
-    return arr.Content[0].Tag == "!!str"
+	if len(arr.Content) == 0 {
+		return false
+	}
+	return arr.Content[0].Tag == "!!str"
 }
 
 func (a Alphabetical) isValidNumberArray(arr *yaml.Node) bool {
-    if len(arr.Content) == 0 {
-        return false
-    }
-    return arr.Content[0].Tag == "!!int" || arr.Content[0].Tag == "!!float"
+	if len(arr.Content) == 0 {
+		return false
+	}
+	return arr.Content[0].Tag == "!!int" || arr.Content[0].Tag == "!!float"
 }
 
 func (a Alphabetical) isValidMapArray(arr *yaml.Node) bool {
-    if len(arr.Content) == 0 {
-        return false
-    }
-    return arr.Content[0].Tag == "!!map"
+	if len(arr.Content) == 0 {
+		return false
+	}
+	return arr.Content[0].Tag == "!!map"
 }
 
 func (a Alphabetical) checkStringArrayIsSorted(arr *yaml.Node, context model.RuleFunctionContext) []model.RuleFunctionResult {
-    var strArr []string
-    for _, n := range arr.Content {
-        if n.Tag == "!!str" {
-            strArr = append(strArr, n.Value)
-        }
-    }
-    if sort.StringsAreSorted(strArr) {
-        return nil
-    }
-    return compareStringArray(strArr, context)
+	var strArr []string
+	for _, n := range arr.Content {
+		if n.Tag == "!!str" {
+			strArr = append(strArr, n.Value)
+		}
+	}
+	if sort.StringsAreSorted(strArr) {
+		return nil
+	}
+	return compareStringArray(strArr, context)
 }
 
 func compareStringArray(strArr []string, context model.RuleFunctionContext) []model.RuleFunctionResult {
-    var results []model.RuleFunctionResult
-    message := context.Rule.Message
+	var results []model.RuleFunctionResult
+	message := context.Rule.Message
 
-    for x := 0; x < len(strArr); x++ {
-        if x+1 < len(strArr) {
-            s := strings.Compare(strArr[x], strArr[x+1])
-            if s > 0 {
-                results = append(results, model.RuleFunctionResult{
-                    Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` must be placed before `%s` (alphabetical)",
-                        context.Rule.Description,
-                        strArr[x+1], strArr[x])),
-                })
-            }
-        }
-    }
-    return results
+	for x := 0; x < len(strArr); x++ {
+		if x+1 < len(strArr) {
+			s := strings.Compare(strArr[x], strArr[x+1])
+			if s > 0 {
+				results = append(results, model.RuleFunctionResult{
+					Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` must be placed before `%s` (alphabetical)",
+						context.Rule.Description,
+						strArr[x+1], strArr[x])),
+				})
+			}
+		}
+	}
+	return results
 }
 
 func (a Alphabetical) checkNumberArrayIsSorted(arr *yaml.Node, context model.RuleFunctionContext) []model.RuleFunctionResult {
-    var results []model.RuleFunctionResult
-    var intArray []int
-    var floatArray []float64
+	var results []model.RuleFunctionResult
+	var intArray []int
+	var floatArray []float64
 
-    for _, n := range arr.Content {
-        if n.Tag == "!!int" {
-            intVal, _ := strconv.Atoi(n.Value)
-            intArray = append(intArray, intVal)
-        }
-        if n.Tag == "!!float" {
-            floatVal, _ := strconv.ParseFloat(n.Value, 64)
-            floatArray = append(floatArray, floatVal)
-        }
-    }
+	for _, n := range arr.Content {
+		if n.Tag == "!!int" {
+			intVal, _ := strconv.Atoi(n.Value)
+			intArray = append(intArray, intVal)
+		}
+		if n.Tag == "!!float" {
+			floatVal, _ := strconv.ParseFloat(n.Value, 64)
+			floatArray = append(floatArray, floatVal)
+		}
+	}
 
-    errmsg := "%s: `%v` is less than `%v`, they need to be swapped (numerical ordering)"
+	errmsg := "%s: `%v` is less than `%v`, they need to be swapped (numerical ordering)"
 
-    if len(floatArray) > 0 {
-        if !sort.Float64sAreSorted(floatArray) {
-            results = a.evaluateFloatArray(floatArray, errmsg, context)
-        }
-    }
+	if len(floatArray) > 0 {
+		if !sort.Float64sAreSorted(floatArray) {
+			results = a.evaluateFloatArray(floatArray, errmsg, context)
+		}
+	}
 
-    if len(intArray) > 0 {
-        if !sort.IntsAreSorted(intArray) {
-            results = append(results, a.evaluateIntArray(intArray, errmsg, context)...)
-        }
-    }
+	if len(intArray) > 0 {
+		if !sort.IntsAreSorted(intArray) {
+			results = append(results, a.evaluateIntArray(intArray, errmsg, context)...)
+		}
+	}
 
-    return results
+	return results
 }
 
 func (a Alphabetical) evaluateIntArray(intArray []int, errmsg string, context model.RuleFunctionContext) []model.RuleFunctionResult {
-    var results []model.RuleFunctionResult
-    message := context.Rule.Message
-    for x, n := range intArray {
-        if x+1 < len(intArray) && n > intArray[x+1] {
-            results = append(results, model.RuleFunctionResult{
-                Message: SuppliedOrDefault(message, fmt.Sprintf(errmsg, context.Rule.Description, intArray[x+1], intArray[x])),
-            })
-        }
-    }
-    return results
+	var results []model.RuleFunctionResult
+	message := context.Rule.Message
+	for x, n := range intArray {
+		if x+1 < len(intArray) && n > intArray[x+1] {
+			results = append(results, model.RuleFunctionResult{
+				Message: SuppliedOrDefault(message, fmt.Sprintf(errmsg, context.Rule.Description, intArray[x+1], intArray[x])),
+			})
+		}
+	}
+	return results
 }
 
 func (a Alphabetical) evaluateFloatArray(floatArray []float64, errmsg string, context model.RuleFunctionContext) []model.RuleFunctionResult {
-    var results []model.RuleFunctionResult
-    message := context.Rule.Message
+	var results []model.RuleFunctionResult
+	message := context.Rule.Message
 
-    for x, n := range floatArray {
-        if x+1 < len(floatArray) && n > floatArray[x+1] {
-            results = append(results, model.RuleFunctionResult{
-                Message: SuppliedOrDefault(message, fmt.Sprintf(errmsg, context.Rule.Description, floatArray[x+1], floatArray[x])),
-            })
-        }
-    }
-    return results
+	for x, n := range floatArray {
+		if x+1 < len(floatArray) && n > floatArray[x+1] {
+			results = append(results, model.RuleFunctionResult{
+				Message: SuppliedOrDefault(message, fmt.Sprintf(errmsg, context.Rule.Description, floatArray[x+1], floatArray[x])),
+			})
+		}
+	}
+	return results
 }

--- a/functions/core/alphabetical.go
+++ b/functions/core/alphabetical.go
@@ -4,13 +4,13 @@
 package core
 
 import (
-	"fmt"
-	"github.com/daveshanley/vacuum/model"
-	"github.com/pb33f/libopenapi/utils"
-	"gopkg.in/yaml.v3"
-	"sort"
-	"strconv"
-	"strings"
+    "fmt"
+    "github.com/daveshanley/vacuum/model"
+    "github.com/pb33f/libopenapi/utils"
+    "gopkg.in/yaml.v3"
+    "sort"
+    "strconv"
+    "strings"
 )
 
 // Alphabetical is a rule that will check an array or object to determine if the values are in order.
@@ -20,223 +20,231 @@ type Alphabetical struct{}
 
 // GetSchema returns a model.RuleFunctionSchema defining the schema of the Alphabetical rule.
 func (a Alphabetical) GetSchema() model.RuleFunctionSchema {
-	return model.RuleFunctionSchema{
-		Name: "alphabetical",
-		Properties: []model.RuleFunctionProperty{
-			{
-				Name:        "keyedBy",
-				Description: "this is the key of an object you want to use to sort objects",
-			},
-		},
-		ErrorMessage: "'alphabetical' function has invalid options supplied. To sort objects use 'keyedBy'" +
-			"and decide which property on the array of objects you want to use.",
-	}
+    return model.RuleFunctionSchema{
+        Name: "alphabetical",
+        Properties: []model.RuleFunctionProperty{
+            {
+                Name:        "keyedBy",
+                Description: "this is the key of an object you want to use to sort objects",
+            },
+        },
+        ErrorMessage: "'alphabetical' function has invalid options supplied. To sort objects use 'keyedBy'" +
+            "and decide which property on the array of objects you want to use.",
+    }
 }
 
 // RunRule will execute the Alphabetical rule, based on supplied context and a supplied []*yaml.Node slice.
 func (a Alphabetical) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) []model.RuleFunctionResult {
-	var results []model.RuleFunctionResult
-	if len(nodes) <= 0 {
-		return nil
-	}
+    var results []model.RuleFunctionResult
+    if len(nodes) <= 0 {
+        return nil
+    }
 
-	var keyedBy string
+    var keyedBy string
 
-	// check supplied type
-	props := utils.ConvertInterfaceIntoStringMap(context.Options)
-	if props["keyedBy"] != "" {
-		keyedBy = props["keyedBy"]
-	}
+    // extract a custom message
+    message := context.Rule.Message
 
-	for _, node := range nodes {
-		pathValue := "unknown"
-		if path, ok := context.Given.(string); ok {
-			pathValue = path
-		}
+    // check supplied type
+    props := utils.ConvertInterfaceIntoStringMap(context.Options)
+    if props["keyedBy"] != "" {
+        keyedBy = props["keyedBy"]
+    }
 
-		if utils.IsNodeMap(node) {
+    for _, node := range nodes {
+        pathValue := "unknown"
+        if path, ok := context.Given.(string); ok {
+            pathValue = path
+        }
 
-			if keyedBy == "" {
-				results = append(results, model.RuleFunctionResult{
-					Message: fmt.Sprintf("%s: `%s` is a map/object. %s", context.Rule.Description,
-						node.Value, a.GetSchema().ErrorMessage),
-					StartNode: node,
-					EndNode:   node,
-					Path:      pathValue,
-					Rule:      context.Rule,
-				})
-				continue
-			}
+        if utils.IsNodeMap(node) {
 
-			resultsFromKey := a.processMap(node, keyedBy, context)
-			results = compareStringArray(resultsFromKey, context)
-			results = model.MapPathAndNodesToResults(pathValue, node, node, results)
-			continue
-		}
+            if keyedBy == "" {
+                results = append(results, model.RuleFunctionResult{
+                    Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` is a map/object. %s", context.Rule.Description,
+                        node.Value, a.GetSchema().ErrorMessage)),
+                    StartNode: node,
+                    EndNode:   node,
+                    Path:      pathValue,
+                    Rule:      context.Rule,
+                })
+                continue
+            }
 
-		if utils.IsNodeArray(node) {
-			if a.isValidArray(node) {
-				if a.isValidStringArray(node) {
-					rs := a.checkStringArrayIsSorted(node, context)
-					results = append(results, rs...)
-				}
+            resultsFromKey := a.processMap(node, keyedBy, context)
+            results = compareStringArray(resultsFromKey, context)
+            results = model.MapPathAndNodesToResults(pathValue, node, node, results)
+            continue
+        }
 
-				if a.isValidNumberArray(node) {
-					rs := a.checkNumberArrayIsSorted(node, context)
-					results = append(results, rs...)
-				}
+        if utils.IsNodeArray(node) {
+            if a.isValidArray(node) {
+                if a.isValidStringArray(node) {
+                    rs := a.checkStringArrayIsSorted(node, context)
+                    results = append(results, rs...)
+                }
 
-				if a.isValidMapArray(node) {
-					resultsFromKey := a.processMap(node, keyedBy, context)
-					results = compareStringArray(resultsFromKey, context)
-				}
-				results = model.MapPathAndNodesToResults(pathValue, node, node, results)
+                if a.isValidNumberArray(node) {
+                    rs := a.checkNumberArrayIsSorted(node, context)
+                    results = append(results, rs...)
+                }
 
-			}
-			continue
-		}
+                if a.isValidMapArray(node) {
+                    resultsFromKey := a.processMap(node, keyedBy, context)
+                    results = compareStringArray(resultsFromKey, context)
+                }
+                results = model.MapPathAndNodesToResults(pathValue, node, node, results)
 
-		// TODO: handle single value code
+            }
+            continue
+        }
 
-	}
+        // TODO: handle single value code
 
-	return results
+    }
+
+    return results
 }
 
 func (a Alphabetical) processMap(node *yaml.Node, keyedBy string, context model.RuleFunctionContext) []string {
-	var resultsFromKey []string
-	for x, v := range node.Content {
-		// run odd numbers for values.
-		if x == 0 || x%2 != 0 {
-			if v.Tag == "!!map" {
+    var resultsFromKey []string
+    for x, v := range node.Content {
+        // run odd numbers for values.
+        if x == 0 || x%2 != 0 {
+            if v.Tag == "!!map" {
 
-				for y, kv := range v.Content {
+                for y, kv := range v.Content {
 
-					// check keys for keyedBy match
-					if y%2 == 0 && keyedBy == kv.Value && y+1 < len(v.Content) {
-						resultsFromKey = append(resultsFromKey, v.Content[y+1].Value)
-					}
-				}
-			}
-		}
-	}
-	return resultsFromKey
+                    // check keys for keyedBy match
+                    if y%2 == 0 && keyedBy == kv.Value && y+1 < len(v.Content) {
+                        resultsFromKey = append(resultsFromKey, v.Content[y+1].Value)
+                    }
+                }
+            }
+        }
+    }
+    return resultsFromKey
 }
 
 func (a Alphabetical) isValidArray(arr *yaml.Node) bool {
-	for _, n := range arr.Content {
-		switch n.Tag {
-		case "!!bool":
-			return false
-		}
-	}
-	return true
+    for _, n := range arr.Content {
+        switch n.Tag {
+        case "!!bool":
+            return false
+        }
+    }
+    return true
 }
 
 func (a Alphabetical) isValidStringArray(arr *yaml.Node) bool {
-	if len(arr.Content) == 0 {
-		return false
-	}
-	return arr.Content[0].Tag == "!!str"
+    if len(arr.Content) == 0 {
+        return false
+    }
+    return arr.Content[0].Tag == "!!str"
 }
 
 func (a Alphabetical) isValidNumberArray(arr *yaml.Node) bool {
-	if len(arr.Content) == 0 {
-		return false
-	}
-	return arr.Content[0].Tag == "!!int" || arr.Content[0].Tag == "!!float"
+    if len(arr.Content) == 0 {
+        return false
+    }
+    return arr.Content[0].Tag == "!!int" || arr.Content[0].Tag == "!!float"
 }
 
 func (a Alphabetical) isValidMapArray(arr *yaml.Node) bool {
-	if len(arr.Content) == 0 {
-		return false
-	}
-	return arr.Content[0].Tag == "!!map"
+    if len(arr.Content) == 0 {
+        return false
+    }
+    return arr.Content[0].Tag == "!!map"
 }
 
 func (a Alphabetical) checkStringArrayIsSorted(arr *yaml.Node, context model.RuleFunctionContext) []model.RuleFunctionResult {
-	var strArr []string
-	for _, n := range arr.Content {
-		if n.Tag == "!!str" {
-			strArr = append(strArr, n.Value)
-		}
-	}
-	if sort.StringsAreSorted(strArr) {
-		return nil
-	}
-	return compareStringArray(strArr, context)
+    var strArr []string
+    for _, n := range arr.Content {
+        if n.Tag == "!!str" {
+            strArr = append(strArr, n.Value)
+        }
+    }
+    if sort.StringsAreSorted(strArr) {
+        return nil
+    }
+    return compareStringArray(strArr, context)
 }
 
 func compareStringArray(strArr []string, context model.RuleFunctionContext) []model.RuleFunctionResult {
-	var results []model.RuleFunctionResult
-	for x := 0; x < len(strArr); x++ {
-		if x+1 < len(strArr) {
-			s := strings.Compare(strArr[x], strArr[x+1])
-			if s > 0 {
-				results = append(results, model.RuleFunctionResult{
-					Message: fmt.Sprintf("%s: `%s` must be placed before `%s` (alphabetical)",
-						context.Rule.Description,
-						strArr[x+1], strArr[x]),
-				})
-			}
-		}
-	}
-	return results
+    var results []model.RuleFunctionResult
+    message := context.Rule.Message
+
+    for x := 0; x < len(strArr); x++ {
+        if x+1 < len(strArr) {
+            s := strings.Compare(strArr[x], strArr[x+1])
+            if s > 0 {
+                results = append(results, model.RuleFunctionResult{
+                    Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` must be placed before `%s` (alphabetical)",
+                        context.Rule.Description,
+                        strArr[x+1], strArr[x])),
+                })
+            }
+        }
+    }
+    return results
 }
 
 func (a Alphabetical) checkNumberArrayIsSorted(arr *yaml.Node, context model.RuleFunctionContext) []model.RuleFunctionResult {
-	var results []model.RuleFunctionResult
-	var intArray []int
-	var floatArray []float64
+    var results []model.RuleFunctionResult
+    var intArray []int
+    var floatArray []float64
 
-	for _, n := range arr.Content {
-		if n.Tag == "!!int" {
-			intVal, _ := strconv.Atoi(n.Value)
-			intArray = append(intArray, intVal)
-		}
-		if n.Tag == "!!float" {
-			floatVal, _ := strconv.ParseFloat(n.Value, 64)
-			floatArray = append(floatArray, floatVal)
-		}
-	}
+    for _, n := range arr.Content {
+        if n.Tag == "!!int" {
+            intVal, _ := strconv.Atoi(n.Value)
+            intArray = append(intArray, intVal)
+        }
+        if n.Tag == "!!float" {
+            floatVal, _ := strconv.ParseFloat(n.Value, 64)
+            floatArray = append(floatArray, floatVal)
+        }
+    }
 
-	errmsg := "%s: `%v` is less than `%v`, they need to be swapped (numerical ordering)"
+    errmsg := "%s: `%v` is less than `%v`, they need to be swapped (numerical ordering)"
 
-	if len(floatArray) > 0 {
-		if !sort.Float64sAreSorted(floatArray) {
-			results = a.evaluateFloatArray(floatArray, errmsg, context)
-		}
-	}
+    if len(floatArray) > 0 {
+        if !sort.Float64sAreSorted(floatArray) {
+            results = a.evaluateFloatArray(floatArray, errmsg, context)
+        }
+    }
 
-	if len(intArray) > 0 {
-		if !sort.IntsAreSorted(intArray) {
-			results = append(results, a.evaluateIntArray(intArray, errmsg, context)...)
-		}
-	}
+    if len(intArray) > 0 {
+        if !sort.IntsAreSorted(intArray) {
+            results = append(results, a.evaluateIntArray(intArray, errmsg, context)...)
+        }
+    }
 
-	return results
+    return results
 }
 
 func (a Alphabetical) evaluateIntArray(intArray []int, errmsg string, context model.RuleFunctionContext) []model.RuleFunctionResult {
-	var results []model.RuleFunctionResult
-	for x, n := range intArray {
-		if x+1 < len(intArray) && n > intArray[x+1] {
-			results = append(results, model.RuleFunctionResult{
-				Message: fmt.Sprintf(errmsg, context.Rule.Description, intArray[x+1], intArray[x]),
-			})
-		}
-	}
-	return results
+    var results []model.RuleFunctionResult
+    message := context.Rule.Message
+    for x, n := range intArray {
+        if x+1 < len(intArray) && n > intArray[x+1] {
+            results = append(results, model.RuleFunctionResult{
+                Message: SuppliedOrDefault(message, fmt.Sprintf(errmsg, context.Rule.Description, intArray[x+1], intArray[x])),
+            })
+        }
+    }
+    return results
 }
 
 func (a Alphabetical) evaluateFloatArray(floatArray []float64, errmsg string, context model.RuleFunctionContext) []model.RuleFunctionResult {
-	var results []model.RuleFunctionResult
-	for x, n := range floatArray {
-		if x+1 < len(floatArray) && n > floatArray[x+1] {
-			results = append(results, model.RuleFunctionResult{
-				Message: fmt.Sprintf(errmsg, context.Rule.Description, floatArray[x+1], floatArray[x]),
-			})
-		}
-	}
-	return results
+    var results []model.RuleFunctionResult
+    message := context.Rule.Message
+
+    for x, n := range floatArray {
+        if x+1 < len(floatArray) && n > floatArray[x+1] {
+            results = append(results, model.RuleFunctionResult{
+                Message: SuppliedOrDefault(message, fmt.Sprintf(errmsg, context.Rule.Description, floatArray[x+1], floatArray[x])),
+            })
+        }
+    }
+    return results
 }

--- a/functions/core/casing.go
+++ b/functions/core/casing.go
@@ -189,7 +189,7 @@ func (c Casing) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) [
 	return results
 }
 
-func (c Casing) compileExpressions() {
+func (c *Casing) compileExpressions() {
 
 	digits := "0-9"
 	if c.ignoreDigits {

--- a/functions/core/casing.go
+++ b/functions/core/casing.go
@@ -78,6 +78,8 @@ func (c Casing) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) [
 
 	var casingType string
 
+	message := context.Rule.Message
+
 	// check supplied type
 	props := utils.ConvertInterfaceIntoStringMap(context.Options)
 	if props["type"] == "" {
@@ -152,7 +154,7 @@ func (c Casing) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) [
 
 		if !rx.MatchString(node.Value) {
 			results = append(results, model.RuleFunctionResult{
-				Message:   fmt.Sprintf("%s: `%s` is not %s case", ruleMessage, node.Value, casingType),
+				Message:   SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` is not %s case", ruleMessage, node.Value, casingType)),
 				StartNode: node,
 				EndNode:   node,
 				Path:      pathValue,
@@ -174,8 +176,8 @@ func (c Casing) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) [
 		rx := regexp.MustCompile(leadingPattern)
 		if !rx.MatchString(nodes[0].Value) {
 			results = append(results, model.RuleFunctionResult{
-				Message: fmt.Sprintf("%s: `%s` is not `%s` case", ruleMessage,
-					nodes[0].Value, casingType),
+				Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` is not `%s` case", ruleMessage,
+					nodes[0].Value, casingType)),
 				StartNode: nodes[0],
 				EndNode:   nodes[0],
 				Path:      pathValue,
@@ -187,7 +189,7 @@ func (c Casing) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) [
 	return results
 }
 
-func (c *Casing) compileExpressions() {
+func (c Casing) compileExpressions() {
 
 	digits := "0-9"
 	if c.ignoreDigits {

--- a/functions/core/defined.go
+++ b/functions/core/defined.go
@@ -31,6 +31,8 @@ func (d Defined) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 
 	var results []model.RuleFunctionResult
 
+	message := context.Rule.Message
+
 	pathValue := "unknown"
 	if path, ok := context.Given.(string); ok {
 		pathValue = path
@@ -45,7 +47,8 @@ func (d Defined) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 		fieldNode, _ := utils.FindKeyNode(context.RuleAction.Field, node.Content)
 		if fieldNode == nil {
 			results = append(results, model.RuleFunctionResult{
-				Message:   fmt.Sprintf("%s: `%s` must be defined", ruleMessage, context.RuleAction.Field),
+				Message: SuppliedOrDefault(message,
+					fmt.Sprintf("%s: `%s` must be defined", ruleMessage, context.RuleAction.Field)),
 				StartNode: node,
 				EndNode:   node,
 				Path:      pathValue,

--- a/functions/core/enumeration.go
+++ b/functions/core/enumeration.go
@@ -41,6 +41,8 @@ func (e Enumeration) RunRule(nodes []*yaml.Node, context model.RuleFunctionConte
 	var results []model.RuleFunctionResult
 	var values []string
 
+	message := context.Rule.Message
+
 	// check supplied values (required)
 	props := utils.ConvertInterfaceIntoStringMap(context.Options)
 	if props["values"] == "" {
@@ -61,8 +63,9 @@ func (e Enumeration) RunRule(nodes []*yaml.Node, context model.RuleFunctionConte
 	for _, node := range nodes {
 		if !e.checkValueAgainstAllowedValues(node.Value, values) {
 			results = append(results, model.RuleFunctionResult{
-				Message: fmt.Sprintf("%s: `%s` must equal to one of: %v", ruleMessage,
-					node.Value, values),
+				Message: SuppliedOrDefault(message,
+					fmt.Sprintf("%s: `%s` must equal to one of: %v", ruleMessage,
+						node.Value, values)),
 				StartNode: node,
 				EndNode:   node,
 				Path:      pathValue,

--- a/functions/core/messages.go
+++ b/functions/core/messages.go
@@ -1,0 +1,11 @@
+// Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package core
+
+func SuppliedOrDefault(supplied, original string) string {
+	if supplied != "" {
+		return supplied
+	}
+	return original
+}

--- a/functions/core/pattern.go
+++ b/functions/core/pattern.go
@@ -68,6 +68,8 @@ func (p Pattern) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 		pathValue = path
 	}
 
+	message := context.Rule.Message
+
 	ruleMessage := context.Rule.Description
 	if context.Rule.Message != "" {
 		ruleMessage = context.Rule.Message
@@ -99,8 +101,9 @@ func (p Pattern) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 			expPath := fmt.Sprintf("%s['%s']", pathValue, currentField)
 			if err != nil {
 				results = append(results, model.RuleFunctionResult{
-					Message: fmt.Sprintf("%s: `%s` cannot be compiled into a regular expression [`%s`]",
-						ruleMessage, p.match, err.Error()),
+					Message: SuppliedOrDefault(message,
+						fmt.Sprintf("%s: `%s` cannot be compiled into a regular expression [`%s`]",
+							ruleMessage, p.match, err.Error())),
 					StartNode: node,
 					EndNode:   node,
 					Path:      expPath,
@@ -109,8 +112,9 @@ func (p Pattern) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 			} else {
 				if !rx.MatchString(node.Value) {
 					results = append(results, model.RuleFunctionResult{
-						Message: fmt.Sprintf("%s: `%s` does not match the expression `%s`", ruleMessage,
-							node.Value, p.match),
+						Message: SuppliedOrDefault(message,
+							fmt.Sprintf("%s: `%s` does not match the expression `%s`", ruleMessage,
+								node.Value, p.match)),
 						StartNode: node,
 						EndNode:   node,
 						Path:      expPath,
@@ -126,8 +130,9 @@ func (p Pattern) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 			expPath := fmt.Sprintf("%s['%s']", pathValue, currentField)
 			if err != nil {
 				results = append(results, model.RuleFunctionResult{
-					Message: fmt.Sprintf("%s: cannot be compiled into a regular expression [`%s`]",
-						ruleMessage, err.Error()),
+					Message: SuppliedOrDefault(message,
+						fmt.Sprintf("%s: cannot be compiled into a regular expression [`%s`]",
+							ruleMessage, err.Error())),
 					StartNode: node,
 					EndNode:   node,
 					Path:      expPath,
@@ -136,7 +141,8 @@ func (p Pattern) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 			} else {
 				if rx.MatchString(node.Value) {
 					results = append(results, model.RuleFunctionResult{
-						Message:   fmt.Sprintf("%s: matches the expression `%s`", ruleMessage, p.notMatch),
+						Message: SuppliedOrDefault(message,
+							fmt.Sprintf("%s: matches the expression `%s`", ruleMessage, p.notMatch)),
 						StartNode: node,
 						EndNode:   node,
 						Path:      expPath,

--- a/functions/core/truthy.go
+++ b/functions/core/truthy.go
@@ -41,9 +41,7 @@ func (t *Truthy) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 	}
 
 	ruleMessage := context.Rule.Description
-	if context.Rule.Message != "" {
-		ruleMessage = context.Rule.Message
-	}
+	message := context.Rule.Message
 
 	for x, node := range nodes {
 
@@ -67,7 +65,8 @@ func (t *Truthy) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 					endNode = node
 				}
 				results = append(results, model.RuleFunctionResult{
-					Message:   fmt.Sprintf("%s: `%s` must be set", ruleMessage, context.RuleAction.Field),
+					Message: SuppliedOrDefault(message,
+						fmt.Sprintf("%s: `%s` must be set", ruleMessage, context.RuleAction.Field)),
 					StartNode: node,
 					EndNode:   endNode,
 					Path:      pathValue,
@@ -75,8 +74,6 @@ func (t *Truthy) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) 
 				})
 			}
 		}
-
 	}
-
 	return results
 }

--- a/functions/core/undefined.go
+++ b/functions/core/undefined.go
@@ -30,15 +30,14 @@ func (u Undefined) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext
 
 	var results []model.RuleFunctionResult
 
+	message := context.Rule.Message
+
 	pathValue := "unknown"
 	if path, ok := context.Given.(string); ok {
 		pathValue = path
 	}
 
 	ruleMessage := context.Rule.Description
-	if context.Rule.Message != "" {
-		ruleMessage = context.Rule.Message
-	}
 
 	for _, node := range nodes {
 
@@ -49,8 +48,8 @@ func (u Undefined) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext
 				val = fmt.Sprintf("'%s' ", context.RuleAction.Field)
 			}
 			results = append(results, model.RuleFunctionResult{
-				Message: fmt.Sprintf("%s: `%s` must be undefined]",
-					ruleMessage, val),
+				Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` must be undefined]",
+					ruleMessage, val)),
 				StartNode: fieldNode,
 				EndNode:   fieldNode,
 				Path:      pathValue,
@@ -58,6 +57,5 @@ func (u Undefined) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext
 			})
 		}
 	}
-
 	return results
 }

--- a/functions/core/xor.go
+++ b/functions/core/xor.go
@@ -63,9 +63,7 @@ func (x Xor) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) []mo
 	seenCount := 0
 
 	ruleMessage := context.Rule.Description
-	if context.Rule.Message != "" {
-		ruleMessage = context.Rule.Message
-	}
+	message := context.Rule.Message
 
 	for _, node := range nodes {
 
@@ -80,8 +78,8 @@ func (x Xor) RunRule(nodes []*yaml.Node, context model.RuleFunctionContext) []mo
 
 		if seenCount != 1 {
 			results = append(results, model.RuleFunctionResult{
-				Message: fmt.Sprintf("%s: `%s` and `%s` must not be both defined or undefined",
-					ruleMessage, properties[0], properties[1]),
+				Message: SuppliedOrDefault(message, fmt.Sprintf("%s: `%s` and `%s` must not be both defined or undefined",
+					ruleMessage, properties[0], properties[1])),
 				StartNode: node,
 				EndNode:   node,
 				Path:      pathValue,

--- a/motor/rule_applicator_test.go
+++ b/motor/rule_applicator_test.go
@@ -1622,7 +1622,7 @@ components:
 			},
 		})
 
-	//nolint:staticcheck // ignore this linting issue, its no a bug, it's on purpose.
+	//nolint:staticcheck // ignore this linting issue, it's not a bug, it's on purpose.
 	time.Sleep(100)
 	assert.True(t, panicRan)
 

--- a/rulesets/examples/custom-ruleset.yaml
+++ b/rulesets/examples/custom-ruleset.yaml
@@ -6,7 +6,7 @@ rules:
     severity: error
     recommended: true
     formats: [oas2, oas3]
-    given: $.info.title
+    given: $.info
     then:
       field: title
       function: pattern

--- a/rulesets/examples/custom-ruleset.yaml
+++ b/rulesets/examples/custom-ruleset.yaml
@@ -4,6 +4,7 @@ rules:
   check-title-is-exactly-this:
     description: Check the title of the spec is exactly, 'this specific thing'
     severity: error
+    message: you have to make the title 'this specific thing'
     recommended: true
     formats: [oas2, oas3]
     given: $.info

--- a/rulesets/remote_ruleset.go
+++ b/rulesets/remote_ruleset.go
@@ -1,0 +1,136 @@
+// Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package rulesets
+
+import (
+	"context"
+	"fmt"
+	"github.com/daveshanley/vacuum/model"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+func CheckForRemoteExtends(extends map[string]string) bool {
+	for k, _ := range extends {
+		if strings.HasPrefix(k, "http") {
+			return true
+		}
+	}
+	return false
+}
+
+func DownloadRemoteRuleSet(ctx context.Context, location string) (*RuleSet, error) {
+
+	if location == "" {
+		return nil, fmt.Errorf("cannot download ruleset, location is empty")
+	}
+
+	ruleResp, ruleRemoteErr := http.Get(location)
+	if ruleRemoteErr != nil {
+		return nil, ruleRemoteErr
+	}
+
+	ruleBytes, bytesErr := io.ReadAll(ruleResp.Body)
+
+	if bytesErr != nil {
+		return nil, bytesErr
+	}
+
+	if len(ruleBytes) <= 0 {
+		return nil, fmt.Errorf("remote ruleset '%s' is empty, cannot extend", location)
+	}
+
+	downloadedRS, rsErr := CreateRuleSetFromData(ruleBytes)
+
+	if rsErr != nil {
+		return nil, rsErr
+	}
+
+	return downloadedRS, nil
+}
+
+func SniffOutAllRemoteRules(
+	ctx context.Context,
+	doneChan chan bool,
+	rsm *ruleSetsModel,
+	location string,
+	visited []string,
+	rs *RuleSet) {
+
+	drs, err := DownloadRemoteRuleSet(ctx, location)
+
+	if err != nil {
+		rsm.logger.Error("cannot download remote ruleset",
+			"location", location, "error", err.Error())
+		return
+	}
+
+	// iterate over the remote ruleset and add the rules in
+	for ruleName, ruleValue := range drs.Rules {
+		rs.Rules[ruleName] = ruleValue
+	}
+	for ruleName, ruleValue := range drs.RuleDefinitions {
+		rs.RuleDefinitions[ruleName] = ruleValue
+	}
+
+	visited = append(visited, location)
+
+	// iterate over the extends and extract everything
+	extends := drs.GetExtendsValue()
+
+	// default and explicitly recommended
+	if extends[SpectralOpenAPI] == SpectralRecommended || extends[SpectralOpenAPI] == SpectralOpenAPI {
+
+		// suck in all recommended rules
+		recommended := rsm.GenerateOpenAPIRecommendedRuleSet()
+		for k, v := range recommended.Rules {
+			rs.Rules[k] = v
+		}
+		for k, v := range recommended.RuleDefinitions {
+			rs.RuleDefinitions[k] = v
+		}
+	}
+
+	// all rules
+	if extends[SpectralOpenAPI] == SpectralAll {
+		// suck in all rules
+		allRules := rsm.openAPIRuleSet
+		for k, v := range allRules.Rules {
+			rs.Rules[k] = v
+		}
+		for k, v := range allRules.RuleDefinitions {
+			rs.RuleDefinitions[k] = v
+		}
+	}
+
+	// no rules!
+	if extends[SpectralOpenAPI] == SpectralOff {
+		if rs.DocumentationURI == "" {
+			rs.DocumentationURI = "https://quobix.com/vacuum/rulesets/no-rules"
+		}
+		rs.Rules = make(map[string]*model.Rule)
+		rs.Description = fmt.Sprintf("All disabled ruleset, processing %d supplied rules", len(rs.RuleDefinitions))
+	}
+
+	// do we have remote extensions?
+	if CheckForRemoteExtends(extends) {
+		for k, _ := range extends {
+			if strings.HasPrefix(k, "http") {
+
+				if slices.Contains(visited, k) {
+					rsm.logger.Warn("ruleset links to its self, circular rulesets are not permitted",
+						"extends", k)
+					return
+				}
+
+				// do down the rabbit hole.
+				SniffOutAllRemoteRules(ctx, doneChan, rsm, k, visited, rs)
+			}
+		}
+	}
+	doneChan <- true
+	return
+}

--- a/rulesets/remote_ruleset.go
+++ b/rulesets/remote_ruleset.go
@@ -18,7 +18,7 @@ import (
 // CheckForRemoteExtends checks if the extends map contains a remote link
 // returns true if it does, false if it does not
 func CheckForRemoteExtends(extends map[string]string) bool {
-	for k, _ := range extends {
+	for k := range extends {
 		if strings.HasPrefix(k, "http") {
 			return true
 		}
@@ -29,7 +29,7 @@ func CheckForRemoteExtends(extends map[string]string) bool {
 // CheckForLocalExtends checks if the extends map contains a local link
 // returns true if it does, false if it does not
 func CheckForLocalExtends(extends map[string]string) bool {
-	for k, _ := range extends {
+	for k := range extends {
 		if filepath.Ext(k) == ".yaml" || filepath.Ext(k) == ".json" {
 			return true
 		}
@@ -166,7 +166,7 @@ func SniffOutAllExternalRules(
 
 	// do we have extensions?
 	if CheckForRemoteExtends(extends) || CheckForLocalExtends(extends) {
-		for k, _ := range extends {
+		for k := range extends {
 			if strings.HasPrefix(k, "http") || filepath.Ext(k) == ".yaml" || filepath.Ext(k) == ".json" {
 				if slices.Contains(visited, k) {
 					rsm.logger.Warn("ruleset links to its self, circular rulesets are not permitted",
@@ -179,5 +179,4 @@ func SniffOutAllExternalRules(
 			}
 		}
 	}
-	return
 }

--- a/rulesets/remote_ruleset.go
+++ b/rulesets/remote_ruleset.go
@@ -30,7 +30,9 @@ func CheckForRemoteExtends(extends map[string]string) bool {
 // returns true if it does, false if it does not
 func CheckForLocalExtends(extends map[string]string) bool {
 	for k := range extends {
-		if filepath.Ext(k) == ".yaml" || filepath.Ext(k) == ".json" {
+		if filepath.Ext(k) == ".yml" ||
+			filepath.Ext(k) == ".yaml" ||
+			filepath.Ext(k) == ".json" {
 			return true
 		}
 	}
@@ -167,7 +169,10 @@ func SniffOutAllExternalRules(
 	// do we have extensions?
 	if CheckForRemoteExtends(extends) || CheckForLocalExtends(extends) {
 		for k := range extends {
-			if strings.HasPrefix(k, "http") || filepath.Ext(k) == ".yaml" || filepath.Ext(k) == ".json" {
+			if strings.HasPrefix(k, "http") ||
+				filepath.Ext(k) == ".yml" ||
+				filepath.Ext(k) == ".yaml" ||
+				filepath.Ext(k) == ".json" {
 				if slices.Contains(visited, k) {
 					rsm.logger.Warn("ruleset links to its self, circular rulesets are not permitted",
 						"extends", k)

--- a/rulesets/remote_ruleset_test.go
+++ b/rulesets/remote_ruleset_test.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package rulesets
+
+import (
+	ctx "context"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestCheckForRemoteExtends_Fail(t *testing.T) {
+	extends := make(map[string]string)
+	extends["bing"] = "bong"
+	assert.False(t, CheckForRemoteExtends(extends))
+}
+
+func TestCheckForRemoteExtends_Success(t *testing.T) {
+	extends := make(map[string]string)
+	extends["http://quobix.com"] = "bong"
+	assert.True(t, CheckForRemoteExtends(extends))
+}
+
+func TestDownloadRemoteRuleSet(t *testing.T) {
+
+	mockRemote := func() *httptest.Server {
+		bs, _ := os.ReadFile("examples/custom-ruleset.yaml")
+		return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			_, _ = rw.Write(bs)
+		}))
+	}
+
+	server := mockRemote()
+	defer server.Close()
+
+	rs, err := DownloadRemoteRuleSet(ctx.Background(), server.URL)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, rs)
+	assert.NotNil(t, rs.RuleDefinitions["check-title-is-exactly-this"])
+}

--- a/rulesets/ruleset_functions.go
+++ b/rulesets/ruleset_functions.go
@@ -502,7 +502,7 @@ func GetAPIServersRule() *model.Rule {
 		Recommended:  true,
 		RuleCategory: model.RuleCategories[model.CategoryValidation],
 		Type:         Validation,
-		Severity:     model.SeverityError,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "oasAPIServers",
 		},

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -246,7 +246,7 @@ func (rsm ruleSetsModel) GenerateRuleSetFromSuppliedRuleSet(ruleset *RuleSet) *R
 
 		go func() {
 
-			for k, _ := range extends {
+			for k := range extends {
 				if strings.HasPrefix(k, "http") || filepath.Ext(k) == ".yaml" || filepath.Ext(k) == ".json" {
 					total++
 					remote := false

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -247,7 +247,10 @@ func (rsm ruleSetsModel) GenerateRuleSetFromSuppliedRuleSet(ruleset *RuleSet) *R
 		go func() {
 
 			for k := range extends {
-				if strings.HasPrefix(k, "http") || filepath.Ext(k) == ".yaml" || filepath.Ext(k) == ".json" {
+				if strings.HasPrefix(k, "http") ||
+					filepath.Ext(k) == ".yml" ||
+					filepath.Ext(k) == ".yaml" ||
+					filepath.Ext(k) == ".json" {
 					total++
 					remote := false
 					if strings.HasPrefix(k, "http") {

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -4,6 +4,7 @@
 package rulesets
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/daveshanley/vacuum/model"
 	"github.com/mitchellh/mapstructure"
@@ -226,6 +228,34 @@ func (rsm ruleSetsModel) GenerateRuleSetFromSuppliedRuleSet(ruleset *RuleSet) *R
 
 	// add definitions.
 	rs.RuleDefinitions = ruleset.RuleDefinitions
+
+	if rs.RuleDefinitions == nil {
+		rs.RuleDefinitions = make(map[string]any)
+	}
+
+	// download remote rulesets
+	if CheckForRemoteExtends(extends) {
+		doneChan := make(chan bool)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		total := 0
+		for k, _ := range extends {
+			if strings.HasPrefix(k, "http") {
+				total++
+				go SniffOutAllRemoteRules(ctx, doneChan, &rsm, k, nil, rs)
+			}
+		}
+		complete := 0
+		for complete < total {
+			select {
+			case <-doneChan:
+				complete++
+			case <-ctx.Done():
+				rsm.logger.Error("remote ruleset download timed out after 5 seconds")
+				break
+			}
+		}
+	}
 
 	// now all the base rules are in, let's run through the raw definitions and decide
 	// what we need to add, enable, disable, replace or change severity on.


### PR DESCRIPTION
## Add support for extending external rulesets, a feature requested by #254 

Now rulesets can be extended easily using local files or remote files. vacuum also supports this feature recursively, which means entire chains of extension rulesets can be created. 

The following syntax is now valid

```yaml
extends:
  - 'spectral:oas'
  - ./rules/stringTypeConstraints.yaml
  - ../things/integerAndNumberTypeConstraints.yml
  - http://somedomain-out-there.com/path/to/rules.yaml
  - http://somwhere-else-out-there.com/more/rules.json
```

## Adds support for feature #278 

Added new `-m` and -`b` banner flags for `lint` command

The banner can now be disabled using the `-b`  or `—no-banner` flag, as well as the message output (when using `-d`) can be disabled with the `-m` or the `—no-message` flags.

## Adds support for #284 

The rule has been downgraded to a warning from an error.

## Adds support for #293 

New `-a` / `—all-results` flag enables all result output #293

Want to see everything when using `-d`, well now you can.

## Adds support for #318 

`message` now overrides all core function messages #318

By adding a ‘message` property to a rule that uses a core function, any violations for that rule, will use the supplied message completely, vs the default output built into vacuum for that core function. This gives complete control over the message presented to users who violate the rule.

For example:

```yaml
extends: [[spectral:oas, off]]
documentationUrl: https://quobix.com/vacuum/rulesets/custom-rulesets
rules:
  check-title-is-exactly-this:
    description: Check the title of the spec is exactly, 'this specific thing'
    severity: error
    message: you have to make the title 'this specific thing'
    recommended: true
    formats: [oas2, oas3]
    given: $.info
    then:
      field: title
      function: pattern
      functionOptions:
        match: 'this specific thing'
    howToFix: Make sure the title matches 'this specific thing'
```

Results in this: 
![Screenshot 2023-12-13 at 11 01 40 AM](https://github.com/daveshanley/vacuum/assets/187345/044b2171-64e4-4cb4-bb0d-db4d9885aff1)

## New `version` command

Will print out the current version `vacuum version`
