### PR TITLE
Remove inconsistent "OWASP API1:2019 - " from rule description

### DIFF
--- a/rulesets/owasp_ruleset_functions.go
+++ b/rulesets/owasp_ruleset_functions.go
@@ -31,7 +31,7 @@ properties:
 		Name:         "Use random IDs that cannot be guessed.",
 		Id:           OwaspNoNumericIDs,
 		Formats:      model.AllFormats,
-		Description:  "OWASP API1:2019 - Use random IDs that cannot be guessed. UUIDs are preferred",
+		Description:  "Use random IDs that cannot be guessed. UUIDs are preferred",
 		Given:        `$.paths..parameters[*][?(@.name == "id" || @.name =~ /(_id|Id|-id)$/)))]`,
 		Resolved:     false,
 		RuleCategory: model.RuleCategories[model.CategoryOWASP],


### PR DESCRIPTION
This is just a very minor change to a rule description that I've had flagged as being inconsistent with other rule descriptions from vacuum; none of the others' descriptions are prefixed with a reference to OWASP, and it's odd that it references the now outdated OWASP 2019.