### PR TITLE
Fixing gomod go version formate error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daveshanley/vacuum
 
-go 1.21.5
+go 1.21
 
 require (
 	github.com/alecthomas/chroma v0.10.0


### PR DESCRIPTION
Fixing this error

An unexpected error has occurred: CalledProcessError: command: ('/usr/lib/go/bin/go', 'install', './...')
return code: 1
stdout: (none)
stderr:
    go: errors parsing go.mod:
    /usr/local/lib/gravity/pre-commit/repo4anvjvke/go.mod:3: invalid go version '1.21.5': must match format 1.23
    
 