### PR TITLE
Add nil check for properties field

### DIFF
--- a/functions/openapi/schema_type.go
+++ b/functions/openapi/schema_type.go
@@ -252,6 +252,13 @@ func (st SchemaTypeCheck) validateObject(schema *base.Schema, context *model.Rul
 
 	if len(schema.Value.Required) > 0 {
 		for i, required := range schema.Value.Required {
+			if schema.Value.Properties == nil {
+			  result := st.buildResult("object contains `required` fields but no `properties`",
+					fmt.Sprintf("%s.%s[%d]", schema.GenerateJSONPath(), "required", i),
+					schema, schema.Value.GoLow().Required.KeyNode, context)
+				results = append(results, result)
+				break
+			}
 			if schema.Value.Properties.GetOrZero(required) == nil {
 				result := st.buildResult(fmt.Sprintf("`required` field `%s` is not defined in `properties`", required),
 					fmt.Sprintf("%s.%s[%d]", schema.GenerateJSONPath(), "required", i),


### PR DESCRIPTION
Fixes a crash when an object has `required` properties, but the `properties` field itself is undefined. Here is a minimal reproducing example:

```yaml
openapi: 3.0.0
info:
  title: Example API
  version: "1.0"
paths:
  /example-post:
    post:
      summary: Create an example object
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/ExampleObject"
      responses:
        201:
          description: Example object created successfully
          content:
            application/json:
              schema:
                type: object
                properties:
                  id:
                    type: string
                    example: "example-id"
components:
  schemas:
    ExampleObject:
      type: object
      required:
        - id

```

This will cause a panic on the main branch:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13e1588]

goroutine 276 [running]:
github.com/pb33f/libopenapi/orderedmap.(*Map[...]).GetOrZero(...)
        /go/pkg/mod/github.com/pb33f/libopenapi@v0.15.1/orderedmap/orderedmap.go:54
github.com/daveshanley/vacuum/functions/openapi.SchemaTypeCheck.validateObject({}, 0x400017c420, 0x400013d850?)
        /opt/vacuum/functions/openapi/schema_type.go:255 +0x518
github.com/daveshanley/vacuum/functions/openapi.SchemaTypeCheck.RunRule({}, {0x30?, 0x1ab79a0?, 0x9a00004000161978?}, {0x40003e04b0, 0x40003ec780, {0x1989980, 0x1eca450}, {0x0, 0x0}, ...})
        /opt/vacuum/functions/openapi/schema_type.go:54 +0x3e0
github.com/daveshanley/vacuum/motor.buildResults({0x40003ec780, 0x40003db680, 0x40003db680, {0x1ed7850, 0x40003e82c0}, 0x40003d62e8, 0x40003d7710, 0x4000296500, 0x40000d6b00, 0x0, ...}, ...)
        /opt/vacuum/motor/rule_applicator.go:768 +0x588
github.com/daveshanley/vacuum/motor.runRule({0x40003ec780, 0x40003db680, 0x40003db680, {0x1ed7850, 0x40003e82c0}, 0x40003d62e8, 0x40003d7710, 0x4000296500, 0x40000d6b00, 0x0, ...}, ...)
        /opt/vacuum/motor/rule_applicator.go:690 +0x910
created by github.com/daveshanley/vacuum/motor.ApplyRulesToRuleSet.func7 in goroutine 224
        /opt/vacuum/motor/rule_applicator.go:553 +0x21c
```