### PR TITLE
Fix `owasp-protection-global-unsafe` rule failing to detect previously recognised cases

### DIFF
--- a/functions/owasp/check_security.go
+++ b/functions/owasp/check_security.go
@@ -132,6 +132,25 @@ func (cd CheckSecurity) RunRule(nodes []*yaml.Node, context model.RuleFunctionCo
 						}
 					}
 				}
+
+				if !nullable && opValue.Security == nil && len(globalSecurity) >= 1 {
+					for i := range globalSecurity {
+						if globalSecurity[i].Value.Requirements == nil || globalSecurity[i].Value.Requirements.Len() <= 0 {
+							securityNode := globalSecurity[i].Value.GoLow().Requirements.ValueNode
+							result := model.RuleFunctionResult{
+								Message: vacuumUtils.SuppliedOrDefault(context.Rule.Message,
+									fmt.Sprintf("`security` has null elements for path `%s` in method `%s`", path, opType)),
+								StartNode: securityNode,
+								EndNode:   securityNode,
+								Path:      globalSecurity[i].GenerateJSONPath(),
+								Rule:      context.Rule,
+							}
+							pathItem.AddRuleFunctionResult(base.ConvertRuleResult(&result))
+							results = append(results, result)
+							continue
+						}
+					}
+				}
 			}
 		}
 	}

--- a/functions/owasp/check_security.go
+++ b/functions/owasp/check_security.go
@@ -2,6 +2,8 @@ package owasp
 
 import (
 	"fmt"
+	"slices"
+
 	"github.com/daveshanley/vacuum/model"
 	vacuumUtils "github.com/daveshanley/vacuum/utils"
 	"github.com/pb33f/doctor/model/high/base"
@@ -9,7 +11,6 @@ import (
 	v3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/pb33f/libopenapi/utils"
 	"gopkg.in/yaml.v3"
-	"slices"
 )
 
 type CheckSecurity struct {
@@ -86,7 +87,6 @@ func (cd CheckSecurity) RunRule(nodes []*yaml.Node, context model.RuleFunctionCo
 				}
 
 				if opValue.Security == nil && globalSecurity == nil {
-
 					result := model.RuleFunctionResult{
 						Message: vacuumUtils.SuppliedOrDefault(context.Rule.Message,
 							fmt.Sprintf("`security` was not defined for path `%s` in method `%s`", path, opType)),
@@ -101,8 +101,7 @@ func (cd CheckSecurity) RunRule(nodes []*yaml.Node, context model.RuleFunctionCo
 
 				}
 
-				if len(opValue.Security) <= 0 && globalSecurity != nil &&
-					(globalSecurity[0].Value.Requirements == nil || globalSecurity[0].Value.Requirements.Len() <= 0) {
+				if opValue.Security != nil && len(opValue.Security) <= 0 {
 					result := model.RuleFunctionResult{
 						Message: vacuumUtils.SuppliedOrDefault(context.Rule.Message,
 							fmt.Sprintf("`security` is empty for path `%s` in method `%s`", path, opType)),

--- a/functions/owasp/check_security_test.go
+++ b/functions/owasp/check_security_test.go
@@ -250,6 +250,8 @@ paths:
   /secure:
     put:
       responses: {}
+      security:
+        - BasicAuth: []
 components:
   securitySchemes:
     BasicAuth:
@@ -277,9 +279,7 @@ components:
 
 	res := CheckSecurity{}.RunRule(nil, ctx)
 
-	assert.Len(t, res, 2)
+	assert.Len(t, res, 1)
 	assert.Equal(t, "`security` was not defined for path `/insecure` in method `put`", res[0].Message)
 	assert.Equal(t, "$.paths['/insecure'].put", res[0].Path)
-	assert.Equal(t, "`security` was not defined for path `/secure` in method `put`", res[1].Message)
-	assert.Equal(t, "$.paths['/secure'].put", res[1].Path)
 }

--- a/functions/owasp/check_security_test.go
+++ b/functions/owasp/check_security_test.go
@@ -242,8 +242,7 @@ func TestCheckSecurity_SecurityGlobalDefined_Empty(t *testing.T) {
 info:
   version: "1.2.3"
   title: "securitySchemes"
-security:
- - {}
+security: []
 paths:
   /insecure:
     put:
@@ -279,8 +278,8 @@ components:
 	res := CheckSecurity{}.RunRule(nil, ctx)
 
 	assert.Len(t, res, 2)
-	assert.Equal(t, "`security` is empty for path `/insecure` in method `put`", res[0].Message)
+	assert.Equal(t, "`security` was not defined for path `/insecure` in method `put`", res[0].Message)
 	assert.Equal(t, "$.paths['/insecure'].put", res[0].Path)
-	assert.Equal(t, "`security` is empty for path `/secure` in method `put`", res[1].Message)
+	assert.Equal(t, "`security` was not defined for path `/secure` in method `put`", res[1].Message)
 	assert.Equal(t, "$.paths['/secure'].put", res[1].Path)
 }

--- a/functions/owasp/check_security_test.go
+++ b/functions/owasp/check_security_test.go
@@ -2,9 +2,10 @@ package owasp
 
 import (
 	"fmt"
+	"testing"
+
 	drModel "github.com/pb33f/doctor/model"
 	"github.com/pb33f/libopenapi"
-	"testing"
 
 	"github.com/daveshanley/vacuum/model"
 	"github.com/stretchr/testify/assert"
@@ -75,15 +76,16 @@ func TestCheckSecurity_SecurityMissingOnOneOperation(t *testing.T) {
 info:
   version: "1.2.3"
   title: "securitySchemes"
+security:
+  - BasicAuth: []
 paths:
   /insecure:
     put:
       responses: {}
+      security: []
   /secure:
     put:
       responses: {}
-      security:
-        - BasicAuth: []
 components:
   securitySchemes:
     BasicAuth:
@@ -112,7 +114,7 @@ components:
 	res := CheckSecurity{}.RunRule(nil, ctx)
 
 	assert.Len(t, res, 1)
-	assert.Equal(t, "`security` was not defined for path `/insecure` in method `put`", res[0].Message)
+	assert.Equal(t, "`security` is empty for path `/insecure` in method `put`", res[0].Message)
 	assert.Equal(t, "$.paths['/insecure'].put", res[0].Path)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/pb33f/doctor => ../doctor

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/doctor v0.0.3
+	github.com/pb33f/doctor v0.0.4
 	github.com/pb33f/libopenapi v0.15.2
 	github.com/pb33f/libopenapi-validator v0.0.40
 	github.com/pterm/pterm v0.12.75
@@ -69,5 +69,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/pb33f/doctor => ../doctor

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/doctor v0.0.3 h1:EeZhRssFoqIgRswVyGYAK0l+AQRQ3akrRCDJEa5z+Yg=
-github.com/pb33f/doctor v0.0.3/go.mod h1:yBs5hFHAoo/eeFvKN9sWwmHmgEPJ2SaotYOJc05GdMU=
+github.com/pb33f/doctor v0.0.4 h1:+JVwBsVwwMR0Um13mODlQ/h/HpFpyNPKieQXk/sEf2c=
+github.com/pb33f/doctor v0.0.4/go.mod h1:yBs5hFHAoo/eeFvKN9sWwmHmgEPJ2SaotYOJc05GdMU=
 github.com/pb33f/libopenapi v0.15.2 h1:Jit99QiDVgrYgTbEeBmzlUnrR/oewH6K24OTVPRbYaU=
 github.com/pb33f/libopenapi v0.15.2/go.mod h1:m+4Pwri31UvcnZjuP8M7TlbR906DXJmMvYsbis234xg=
 github.com/pb33f/libopenapi-validator v0.0.40 h1:oS/kPLnzX0GgtjrQkwsaqN2m/xHiYONWqRQ57gQ2K5U=


### PR DESCRIPTION
Fixes #431 

Blocked by https://github.com/pb33f/doctor/pull/1 - once merged I can remove the replacement from the `go.mod` here.