### PR TITLE
Add globbing of files for linting

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -261,6 +261,7 @@ func GetLintCommand() *cobra.Command {
 	cmd.Flags().StringP("fail-severity", "n", model.SeverityError, "Results of this level or above will trigger a failure exit code")
 	cmd.Flags().Bool("ignore-array-circle-ref", false, "Ignore circular array references")
 	cmd.Flags().Bool("ignore-polymorph-circle-ref", false, "Ignore circular polymorphic references")
+	// TODO: Add globbed-files flag to other commands as well
 	cmd.Flags().String("globbed-files", "", "Glob pattern of files to lint")
 
 	regErr := cmd.RegisterFlagCompletionFunc("category", cobra.FixedCompletions([]string{

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -39,7 +39,7 @@ func GetLintCommand() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			globPattern, _ := cmd.PersistentFlags().GetString("globbed-files")
+			globPattern, _ := cmd.Flags().GetString("globbed-files")
 			detailsFlag, _ := cmd.Flags().GetBool("details")
 			timeFlag, _ := cmd.Flags().GetBool("time")
 			snippetsFlag, _ := cmd.Flags().GetBool("snippets")

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -73,7 +73,12 @@ func GetLintCommand() *cobra.Command {
 				PrintBanner()
 			}
 
-			filesToLint := getFilesToLint(globPattern, args)
+			filesToLint, err := getFilesToLint(globPattern, args)
+			if err != nil {
+				pterm.Error.Printf("Error getting files to lint: %v\n", err)
+				pterm.Println()
+				return err
+			}
 			for _, file := range filesToLint {
 				// Verify that the each file has a valid extension
 				if !hasValidExtension(file, validFileExtensions) {
@@ -262,7 +267,7 @@ func GetLintCommand() *cobra.Command {
 	cmd.Flags().StringP("fail-severity", "n", model.SeverityError, "Results of this level or above will trigger a failure exit code")
 	cmd.Flags().Bool("ignore-array-circle-ref", false, "Ignore circular array references")
 	cmd.Flags().Bool("ignore-polymorph-circle-ref", false, "Ignore circular polymorphic references")
-	cmd.PersistentFlags().String("globbed-files", "", "Glob pattern of files to lint")
+	cmd.Flags().String("globbed-files", "", "Glob pattern of files to lint")
 
 	regErr := cmd.RegisterFlagCompletionFunc("category", cobra.FixedCompletions([]string{
 		model.CategoryAll,
@@ -591,11 +596,10 @@ func RenderSummary(rs *model.RuleResultSet, silent bool, totalFiles, fileIndex i
 
 }
 
-func getFilesToLint(globPattern string, filenames []string) []string {
+func getFilesToLint(globPattern string, filenames []string) ([]string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
-		pterm.Error.Println(err)
-		os.Exit(1)
+		return []string{}, err
 	}
 	// The user may pass in filenames (the args), a glob pattern, or both.
 	// We simply concatenate them together, and remove any duplicates we may find.
@@ -603,13 +607,11 @@ func getFilesToLint(globPattern string, filenames []string) []string {
 	for _, filename := range filenames {
 		absFilepath, err := filepath.Abs(filename)
 		if err != nil {
-			pterm.Error.Println(err)
-			os.Exit(1)
+			return []string{}, err
 		}
 		cleanedRelFilepath, err := filepath.Rel(dir, filepath.Clean(absFilepath))
 		if err != nil {
-			pterm.Error.Println(err)
-			os.Exit(1)
+			return []string{}, err
 		}
 		filesToLint = append(filesToLint, cleanedRelFilepath)
 	}
@@ -621,20 +623,17 @@ func getFilesToLint(globPattern string, filenames []string) []string {
 		globPattern = strings.TrimPrefix(globPattern, "/")
 		matches, err := filepath.Glob(globPattern)
 		if err != nil {
-			pterm.Error.Println(err)
-			os.Exit(1)
+			return []string{}, err
 		}
 		var relMatches []string
 		for _, match := range matches {
 			absMatch, err := filepath.Abs(match)
 			if err != nil {
-				pterm.Error.Println(err)
-				os.Exit(1)
+				return []string{}, err
 			}
 			cleanedRelFilepath, err := filepath.Rel(dir, filepath.Clean(absMatch))
 			if err != nil {
-				pterm.Error.Println(err)
-				os.Exit(1)
+				return []string{}, err
 			}
 			relMatches = append(relMatches, cleanedRelFilepath)
 		}
@@ -643,7 +642,7 @@ func getFilesToLint(globPattern string, filenames []string) []string {
 	}
 	filesToLint = deduplicate(filesToLint)
 
-	return filesToLint
+	return filesToLint, nil
 }
 
 func deduplicate(input []string) []string {


### PR DESCRIPTION
This is adds the globbing feature very shortly discussed here: #406  (specifically, [here](https://github.com/daveshanley/vacuum/issues/406#issuecomment-1880737357))

It allows for typing something like this `vacuum lint --globbed-files="*/**/bu*.openapi.yaml" model/test_files/badref-burgershop.openapi.yaml`, which will glob files relative to the current working directory. 

It is also possible to combine globbing with the current way of specifying files (just providing filepath(s)), it removes duplicates (meaning, if you provide a filepath twice, or if one of your filepaths provided is also a match result of globbing).

This is my first time actually contributing code to an open source project - so, I'm expecting quite a lot of feedback/criticism. I'm eager to learn!