### PR TITLE
Fixed `owasp-rate-limit` function by removing duplicate name

### DIFF
--- a/rulesets/owasp_ruleset_functions.go
+++ b/rulesets/owasp_ruleset_functions.go
@@ -274,7 +274,7 @@ func GetOWASPRateLimitRule() *model.Rule {
 		xRatelimitLimit = "X-RateLimit-Limit"
 		xRateLimitLimit = "X-Rate-Limit-Limit"
 		ratelimitLimit  = "RateLimit-Limit||RateLimit-Reset"
-		ratelimit       = "RateLimit-Limit"
+		ratelimit       = "RateLimit"
 	)
 
 	return &model.Rule{


### PR DESCRIPTION
Not sure how I missed this one, but I double checked and this needs to be corrected.

