### PR TITLE
Implemented an --ignore-file option to lint/report commands to ignore specific errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,35 @@ recognizes a compressed report file and will deal with it automatically when rea
 
 > When using compression, the file name will be `vacuum-report-MM-DD-YY-HH_MM_SS.json.gz`. vacuum uses gzip internally.
 
+## Ignoring specific linting errors
+
+You can ignore specific linting errors by providing an `--ignore-file` argument to the `lint` and `report` commands.
+
+```
+./vacuum lint --ignore-file <path-to-ignore-file.yaml> -d <your-openapi-spec.yaml>
+```
+
+```
+./vacuum report --ignore-file <path-to-ignore-file.yaml> -c <your-openapi-spec.yaml> <report-prefix>
+```
+
+The ignore-file should point to a .yaml file that contains a list of errors to be ignored by vacuum. The structure of the
+yaml file is as follows:
+
+```
+<rule-id-1>:
+  - <json_path_to_error_or_warning_1>
+  - <json_path_to_error_or_warning_2>
+<rule-id-2>:
+  - <json_path_to_error_or_warning_1>
+  - <json_path_to_error_or_warning_2>
+  ...
+```
+
+Ignoring errors is useful for when you want to implement new rules to existing production APIs. In some cases, 
+correcting the lint errors would result in a breaking change. Having a way to ignore these errors allows you to implement
+the new rules for new APIs while maintaining backwards compatibility for existing ones.
+
 ---
 
 ## Try out the dashboard

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/daveshanley/vacuum/model"
+	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
@@ -561,6 +562,9 @@ rules:
 	tmp, _ := os.CreateTemp("", "")
 	_, _ = io.WriteString(tmp, yaml)
 
+	b := bytes.NewBufferString("")
+	pterm.SetDefaultOutput(b)
+
 	cmd := GetLintCommand()
 	cmd.PersistentFlags().StringP("ruleset", "r", "", "")
 	cmd.SetArgs([]string{
@@ -573,4 +577,5 @@ rules:
 	})
 	cmdErr := cmd.Execute()
 	assert.NoError(t, cmdErr)
+	assert.Contains(t, b.String(), "Linting passed")
 }

--- a/cmd/vacuum_report_test.go
+++ b/cmd/vacuum_report_test.go
@@ -190,3 +190,35 @@ func TestGetVacuumReportCommand_BadFile(t *testing.T) {
 	assert.Error(t, cmdErr)
 
 }
+
+func TestGetVacuumReport_WithIgnoreFile(t *testing.T) {
+
+	yaml := `
+extends: [[spectral:oas, recommended]]
+rules:
+    url-starts-with-major-version:
+        description: Major version must be the first URL component
+        message: All paths must start with a version number, eg /v1, /v2
+        given: $.paths
+        severity: error
+        then:
+            function: pattern
+            functionOptions:
+                match: "/v[0-9]+/"
+`
+
+	tmp, _ := os.CreateTemp("", "")
+	_, _ = io.WriteString(tmp, yaml)
+
+	cmd := GetVacuumReportCommand()
+	cmd.PersistentFlags().StringP("ruleset", "r", "", "")
+	cmd.SetArgs([]string{
+		"--ignore-file",
+		"../model/test_files/burgershop.ignorefile.yaml",
+		"-r",
+		tmp.Name(),
+		"../model/test_files/burgershop.openapi.yaml",
+	})
+	cmdErr := cmd.Execute()
+	assert.NoError(t, cmdErr)
+}

--- a/cmd/vacuum_report_test.go
+++ b/cmd/vacuum_report_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
@@ -210,6 +211,9 @@ rules:
 	tmp, _ := os.CreateTemp("", "")
 	_, _ = io.WriteString(tmp, yaml)
 
+	b := bytes.NewBufferString("")
+	pterm.SetDefaultOutput(b)
+
 	cmd := GetVacuumReportCommand()
 	cmd.PersistentFlags().StringP("ruleset", "r", "", "")
 	cmd.SetArgs([]string{
@@ -221,4 +225,5 @@ rules:
 	})
 	cmdErr := cmd.Execute()
 	assert.NoError(t, cmdErr)
+	assert.Contains(t, b.String(), "SUCCESS")
 }

--- a/model/rules.go
+++ b/model/rules.go
@@ -68,6 +68,8 @@ type RuleFunctionResult struct {
 	ModelContext any `json:"-" yaml:"-"`
 }
 
+type IgnoredItems map[string][]string
+
 // RuleResultSet contains all the results found during a linting run, and all the methods required to
 // filter, sort and calculate counts.
 type RuleResultSet struct {

--- a/model/test_files/burgershop.ignorefile.yaml
+++ b/model/test_files/burgershop.ignorefile.yaml
@@ -1,0 +1,6 @@
+url-starts-with-major-version:
+  - $.paths['/burgers']
+  - $.paths['/burgers/{burgerId}']
+  - $.paths['/burgers/{burgerId}/dressings']
+  - $.paths['/dressings/{dressingId}']
+  - $.paths['/dressings']

--- a/utils/lint_file_request.go
+++ b/utils/lint_file_request.go
@@ -30,6 +30,7 @@ type LintFileRequest struct {
 	TimeoutFlag              int
 	IgnoreArrayCircleRef     bool
 	IgnorePolymorphCircleRef bool
+	IgnoredResults           model.IgnoredItems
 	DefaultRuleSets          rulesets.RuleSets
 	SelectedRS               *rulesets.RuleSet
 	Functions                map[string]model.RuleFunction


### PR DESCRIPTION
The ignore-file is a YAML file that lists the paths for each rule for which to ignore errors for.
It can be used when introducing new linting rules which require breaking changes to existing production APIs.

In the example below, say I want to add a lint rule that new URLs must have a version in the path. This would break existing URLs which do not have versions in their path. We can use the ignorefile to grandfather those APIs while enforcing new APIs start using versioning.

Example ignorefile.yml using the burgershop API in the tests:

```
url-starts-with-major-version:
  - $.paths['/burgers']
  - $.paths['/burgers/{burgerId}']
  - $.paths['/burgers/{burgerId}/dressings']
  - $.paths['/dressings/{dressingId}']
  - $.paths['/dressings']
 ```