### PR TITLE
Fix Spectral severity SeverityInfo

### DIFF
--- a/model/results.go
+++ b/model/results.go
@@ -92,6 +92,8 @@ func (rr *RuleResultSet) GenerateSpectralReport(source string) []reports.Spectra
 		case SeverityError:
 			sev = 0
 		case SeverityInfo:
+			sev = 2
+		case SeverityHint:
 			sev = 3
 		}
 


### PR DESCRIPTION
Maybe there's some reason/context for this that I might be missing. I noticed the severity for the Spectral report changes when having `Info`. However, Spectral also defines 4 different severity levels, see https://github.com/stoplightio/types/blob/42fe3c8980b8064c7393363366ba54182bb35613/src/diagnostics.ts#L6-L27