### PR TITLE
Do not print success with silent enabled

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -255,7 +255,7 @@ func GetLintCommand() *cobra.Command {
 				completed++
 			}
 
-			if !detailsFlag {
+			if !detailsFlag && !silent {
 				pterm.Println()
 				pterm.Info.Println("To see full details of linting report, use the '-d' flag.")
 				pterm.Println()
@@ -614,6 +614,10 @@ func RenderSummary(rs *model.RuleResultSet, silent bool, totalFiles, fileIndex i
 		if informs > 0 {
 			pterm.DefaultHeader.WithBackgroundStyle(pterm.NewStyle(pterm.BgGreen)).WithMargin(10).Printf(
 				"Linting passed, %v informs reported", informsHuman)
+			return
+		}
+
+		if silent {
 			return
 		}
 


### PR DESCRIPTION
This makes vacuum not print this message if there are no issues and silent mode (`-x` or `--silent`) is enabled:

![image](https://github.com/user-attachments/assets/cff09d9e-93d5-4309-a6c1-a348e1cf7153)

Instead, we get no output, which is what i would expect from a silent flag. The errors and warnings are still printed as usual