### PR TITLE
fix: do not override node lookup timeout concurrently

### DIFF
--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -643,8 +643,12 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 		indexConfig.Logger.Debug("running rules", "total", totalRules)
 		now = time.Now()
 
+		// if there are no time outs, set them to defaults
 		if execution.Timeout <= 0 {
-			execution.Timeout = time.Second * 5 // default
+			execution.Timeout = time.Second * 5
+		}
+		if execution.NodeLookupTimeout <= 0 {
+			execution.NodeLookupTimeout = time.Millisecond * 500
 		}
 
 		for _, rule := range execution.RuleSet.Rules {
@@ -658,11 +662,6 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 					info = specInfoUnresolved
 					ruleSpec = specUnresolved
 					ruleIndex = indexUnresolved
-				}
-
-				// if there is no time out, set it to 500ms
-				if execution.NodeLookupTimeout <= 0 {
-					execution.NodeLookupTimeout = time.Millisecond * 500
 				}
 
 				// this list of things is most likely going to grow a bit, so we use a nice clean message design.


### PR DESCRIPTION
In 6455a5b3, `NodeLookupTimeout` was added to the `ruleContext`, but setting its default value was added to a function that is run for every rule from `RuleSet.Rules` concurrently, causing a data race. This fixes that by moving setting the default outside of the concurrent code.

```text
==================
WARNING: DATA RACE
Read at 0x00c000716728 by goroutine 56:
  github.com/daveshanley/vacuum/motor.ApplyRulesToRuleSet.func7()
      /Users/grzegorz.burzynski@konghq.com/go/pkg/mod/github.com/daveshanley/vacuum@v0.16.2/motor/rule_applicator.go:664 +0x158
  github.com/daveshanley/vacuum/motor.ApplyRulesToRuleSet.gowrap1()
      /Users/grzegorz.burzynski@konghq.com/go/pkg/mod/github.com/daveshanley/vacuum@v0.16.2/motor/rule_applicator.go:704 +0x54

Previous write at 0x00c000716728 by goroutine 57:
  github.com/daveshanley/vacuum/motor.ApplyRulesToRuleSet.func7()
      /Users/grzegorz.burzynski@konghq.com/go/pkg/mod/github.com/daveshanley/vacuum@v0.16.2/motor/rule_applicator.go:665 +0x170
  github.com/daveshanley/vacuum/motor.ApplyRulesToRuleSet.gowrap1()
      /Users/grzegorz.burzynski@konghq.com/go/pkg/mod/github.com/daveshanley/vacuum@v0.16.2/motor/rule_applicator.go:704 +0x54
```