### PR TITLE
Bug Fix: Regex Pattern Validation

### DIFF
--- a/functions/openapi/schema_type.go
+++ b/functions/openapi/schema_type.go
@@ -4,12 +4,12 @@ package openapi
 
 import (
 	"fmt"
+
 	"github.com/daveshanley/vacuum/model"
 	vacuumUtils "github.com/daveshanley/vacuum/utils"
 	"github.com/dop251/goja"
 	"github.com/pb33f/doctor/model/high/base"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 // SchemaTypeCheck will determine if document schemas contain the correct type
@@ -145,7 +145,7 @@ func (st SchemaTypeCheck) validateString(schema *base.Schema, context *model.Rul
 
 	if schema.Value.Pattern != "" {
 		vm := goja.New()
-		script := strings.Replace("const regex = new RegExp('{pattern}');", "{pattern}", schema.Value.Pattern, 1)
+		script := fmt.Sprintf("const regex = new RegExp(%q)", schema.Value.Pattern)
 		_, err := vm.RunString(script)
 		if err != nil {
 			result := st.buildResult("schema `pattern` should be a ECMA-262 regular expression dialect",

--- a/functions/openapi/schema_type_test.go
+++ b/functions/openapi/schema_type_test.go
@@ -5,11 +5,12 @@ package openapi
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/daveshanley/vacuum/model"
 	drModel "github.com/pb33f/doctor/model"
 	"github.com/pb33f/libopenapi"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSchemaType_Invalid(t *testing.T) {
@@ -188,8 +189,11 @@ func TestSchemaType_ValidPattern(t *testing.T) {
 components:
   schemas:
     Gum:
-     type: string
-     pattern: hello`
+      type: string
+      pattern: hello
+    Apostrophe:
+      type: string
+      pattern: '[''"]'`
 
 	document, err := libopenapi.NewDocument([]byte(yml))
 	if err != nil {


### PR DESCRIPTION
### Overview
This fixes an edge case where string schema's `pattern` containing an apostrophe causes a false positive.

### Details
Previously a regex pattern `["']` would produce javascript `const regex = new RegExp('["']')` which would be invalid due to `'` in the pattern terminating the string early. Using `fmt.Sprintf`  with  `%q` solves this by automatically escaping/using non-clashing apostrophes to build the string.

This should also fix Issue #629
