### PR TITLE
v0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ come say hi!
 
 ## Documentation
 
-
 🔥 **New in** `v0.17` 🔥 : **Github Action**.
 
 vacuum now has an official Github Action. [Read the docs](https://quobix.com/vacuum/github-action/), or check it out

--- a/README.md
+++ b/README.md
@@ -118,7 +118,16 @@ come say hi!
 
 ## Documentation
 
-🔥 **New in** `v0.16.11` 🔥 : **Composed bundling mode**.
+
+🔥 **New in** `v0.17` 🔥 : **Github Action**.
+
+vacuum now has an official Github Action. [Read the docs](https://quobix.com/vacuum/github-action/), or check it out
+in the [GitHub Marketplace](https://github.com/marketplace/actions/vacuum-openapi-linter-and-quality-analysis-tool).
+
+---
+
+
+`v0.16.11`: **Composed bundling mode**.
 
 A different way to bundle exploded OpenAPI specifications into a single file. [Read the docs](https://quobix.com/vacuum/commands/bundle/).
 
@@ -140,7 +149,7 @@ $refs being used in path items.
 
 ---
 
-v0.14+`: **Engine Speedup**.
+`v0.14+`: **Engine Speedup**.
 
 **Speed!** We've made some significant improvements to how efficiently large documents are walked
 Which means vacuum is now faster than ever.

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -311,10 +311,16 @@ func GetLintCommand() *cobra.Command {
 				// check overall-score is above the threshold
 				if stats != nil {
 					if stats.OverallScore < minScore {
-						box := pterm.DefaultBox.WithLeftPadding(5).WithRightPadding(5)
-						box.BoxStyle = pterm.NewStyle(pterm.FgLightRed)
-						box.Println(pterm.LightRed("🚨 SCORE THRESHOLD FAILED 🚨"))
-						pterm.Println()
+
+						if !pipelineOutput {
+							box := pterm.DefaultBox.WithLeftPadding(5).WithRightPadding(5)
+							box.BoxStyle = pterm.NewStyle(pterm.FgLightRed)
+							box.Println(pterm.LightRed("🚨 SCORE THRESHOLD FAILED 🚨"))
+							pterm.Println()
+						} else {
+							pterm.Println(pterm.LightRed("\n> 🚨 SCORE THRESHOLD FAILED, PIPELINE WILL FAIL 🚨\n"))
+
+						}
 						return fmt.Errorf("score threshold failed, overall score is %d, and the threshold is %d", stats.OverallScore, minScore)
 					}
 				}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -276,6 +276,7 @@ func GetLintCommand() *cobra.Command {
 						IgnoredResults:           ignoredItems,
 						ExtensionRefs:            extensionRefsFlag,
 						PipelineOutput:           pipelineOutput,
+						ShowRules:                showRules,
 					}
 					st, fs, fp, err := lintFile(lfr)
 
@@ -336,7 +337,7 @@ func GetLintCommand() *cobra.Command {
 	cmd.Flags().BoolP("no-banner", "b", false, "Disable the banner / header output")
 	cmd.Flags().BoolP("no-message", "m", false, "Hide the message output when using -d to show details")
 	cmd.Flags().BoolP("all-results", "a", false, "Render out all results, regardless of the number when using -d")
-	cmd.Flags().StringP("fail-severity", "n", model.SeverityError, "Results of this level or above will trigger a failure exit code (e.g. 'info', 'warn', 'error')")
+	cmd.Flags().StringP("fail-severity", "n", model.SeverityError, "Results of this level or above will trigger a failure exit code (e.g. 'info', 'warn', 'error' or 'none')")
 	cmd.Flags().Bool("ignore-array-circle-ref", false, "Ignore circular array references")
 	cmd.Flags().Bool("ignore-polymorph-circle-ref", false, "Ignore circular polymorphic references")
 	cmd.Flags().String("ignore-file", "", "Path to ignore file")
@@ -365,6 +366,7 @@ func GetLintCommand() *cobra.Command {
 		model.SeverityInfo,
 		model.SeverityWarn,
 		model.SeverityError,
+		model.SeverityNone,
 	}, cobra.ShellCompDirectiveNoFileComp)); regErr != nil {
 		panic(regErr)
 	}
@@ -489,6 +491,7 @@ func lintFile(req utils.LintFileRequest) (*reports.ReportStatistics, int64, int,
 			PipelineOutput: req.PipelineOutput,
 			RuleSet:        req.SelectedRS,
 			ReportStats:    stats,
+			RenderRules:    req.ShowRules,
 		}
 
 		RenderSummary(rso)
@@ -522,6 +525,7 @@ func lintFile(req utils.LintFileRequest) (*reports.ReportStatistics, int64, int,
 		PipelineOutput: req.PipelineOutput,
 		RuleSet:        req.SelectedRS,
 		ReportStats:    stats,
+		RenderRules:    req.ShowRules,
 	}
 	RenderSummary(rso)
 
@@ -716,6 +720,7 @@ type RenderSummaryOptions struct {
 	Silent         bool
 	PipelineOutput bool
 	ReportStats    *reports.ReportStatistics
+	RenderRules    bool
 }
 
 // The user may pass in filenames, a glob pattern, or both.

--- a/cmd/lint_render_summary.go
+++ b/cmd/lint_render_summary.go
@@ -212,6 +212,7 @@ func RenderSummary(rso RenderSummaryOptions) {
 			buf.WriteString(fmt.Sprint("✅ You have a perfect score! **Congratulations, you're doing it right.**\n\n"))
 		}
 
+		buf.WriteString(fmt.Sprintf("> learn more about vacuum at [quobix.com/vacuum](https://quobix/vacuum/)\n"))
 		fmt.Print(buf.String())
 		return
 	}

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -455,7 +455,7 @@ func TestGetLintCommand_Details_NoCat_Snippets(t *testing.T) {
 
 func TestGetLintCommand_Details_ErrorOverride(t *testing.T) {
 
-	yaml := `extends: [[spectral:oas, recommended]]
+	yaml := `extends: [[vacuum:oas, recommended]]
 rules:
   oas3-valid-schema-example: error`
 
@@ -483,7 +483,7 @@ rules:
 
 func TestGetLintCommand_Details_Snippets(t *testing.T) {
 
-	yaml := `extends: [[spectral:oas, off]]
+	yaml := `extends: [[vacuum:oas, off]]
 rules:
   oas3-valid-schema-example: true`
 
@@ -546,7 +546,7 @@ func TestFilterIgnoredResults(t *testing.T) {
 func TestGetLintCommand_Details_WithIgnoreFile(t *testing.T) {
 
 	yaml := `
-extends: [[spectral:oas, recommended]]
+extends: [[vacuum:oas, recommended]]
 rules:
     url-starts-with-major-version:
         description: Major version must be the first URL component

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ func GetRootCommand() *cobra.Command {
 	}
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file (defaults to ./vacuum.conf.yaml) ")
 	rootCmd.PersistentFlags().BoolP("time", "t", false, "Show how long vacuum took to run")
-	rootCmd.PersistentFlags().StringP("ruleset", "r", "", "Path to a spectral ruleset configuration")
+	rootCmd.PersistentFlags().StringP("ruleset", "r", "", "Location of a vacuum (or Spectral) ruleset")
 	rootCmd.PersistentFlags().StringP("functions", "f", "", "Path to custom functions")
 	rootCmd.PersistentFlags().StringP("base", "p", "", "Override Base URL or path to use for resolving local file based or remote references")
 	rootCmd.PersistentFlags().BoolP("remote", "u", true, "Allow local files and remote (http) references to be looked up")

--- a/cmd/shared_functions.go
+++ b/cmd/shared_functions.go
@@ -98,6 +98,9 @@ func LoadCustomFunctions(functionsFlag string, silence bool) (map[string]model.R
 }
 
 func CheckFailureSeverity(failSeverityFlag string, errors int, warnings int, informs int) error {
+	if failSeverityFlag == model.SeverityNone {
+		return nil
+	}
 	if failSeverityFlag != model.SeverityError {
 		switch failSeverityFlag {
 		case model.SeverityWarn:

--- a/cmd/vacuum_report_test.go
+++ b/cmd/vacuum_report_test.go
@@ -195,7 +195,7 @@ func TestGetVacuumReportCommand_BadFile(t *testing.T) {
 func TestGetVacuumReport_WithIgnoreFile(t *testing.T) {
 
 	yaml := `
-extends: [[spectral:oas, recommended]]
+extends: [[vacuum:oas, recommended]]
 rules:
     url-starts-with-major-version:
         description: Major version must be the first URL component

--- a/model/rules.go
+++ b/model/rules.go
@@ -19,6 +19,7 @@ const (
 	SeverityWarn         = "warn"
 	SeverityInfo         = "info"
 	SeverityHint         = "hint"
+	SeverityNone         = "none"
 	CategoryExamples     = "examples"
 	CategoryOperations   = "operations"
 	CategoryInfo         = "information"

--- a/rulesets/examples/all-ruleset.yaml
+++ b/rulesets/examples/all-ruleset.yaml
@@ -1,1 +1,1 @@
-extends: [[spectral:oas, all]]
+extends: [[vacuum:oas, all]]

--- a/rulesets/examples/custom-ruleset.yaml
+++ b/rulesets/examples/custom-ruleset.yaml
@@ -1,4 +1,4 @@
-extends: [[spectral:oas, off]]
+extends: [[vacuum:oas, off]]
 documentationUrl: https://quobix.com/vacuum/rulesets/custom-rulesets
 rules:
   check-title-is-exactly-this:

--- a/rulesets/examples/norules-ruleset.yaml
+++ b/rulesets/examples/norules-ruleset.yaml
@@ -1,1 +1,1 @@
-extends: [[spectral:oas, off]]
+extends: [[vacuum:oas, off]]

--- a/rulesets/examples/recommended-ruleset.yaml
+++ b/rulesets/examples/recommended-ruleset.yaml
@@ -1,1 +1,1 @@
-extends: [[spectral:oas, recommended]]
+extends: [[vacuum:oas, recommended]]

--- a/rulesets/examples/sample-plugin-ruleset.yaml
+++ b/rulesets/examples/sample-plugin-ruleset.yaml
@@ -1,4 +1,4 @@
-extends: [[spectral:oas, off]]
+extends: [[vacuum:oas, off]]
 documentationUrl: https://quobix.com/vacuum/rulesets/custom-rulesets
 rules:
   sample-plugin-rule:

--- a/rulesets/examples/specific-ruleset.yaml
+++ b/rulesets/examples/specific-ruleset.yaml
@@ -1,4 +1,4 @@
-extends: [[spectral:oas, off]]
+extends: [[vacuum:oas, off]]
 rules:
   oas3-valid-schema-example: true
   oas3-missing-example: true

--- a/rulesets/remote_ruleset.go
+++ b/rulesets/remote_ruleset.go
@@ -137,7 +137,8 @@ func SniffOutAllExternalRules(
 	extends := drs.GetExtendsValue()
 
 	// default and explicitly recommended
-	if extends[SpectralOpenAPI] == SpectralRecommended || extends[SpectralOpenAPI] == SpectralOpenAPI {
+	if (extends[SpectralOpenAPI] == VacuumRecommended || extends[SpectralOpenAPI] == SpectralOpenAPI) ||
+		(extends[VacuumOpenAPI] == VacuumRecommended || extends[VacuumOpenAPI] == VacuumOpenAPI) {
 
 		// suck in all recommended rules
 		recommended := rsm.GenerateOpenAPIRecommendedRuleSet()
@@ -154,7 +155,7 @@ func SniffOutAllExternalRules(
 	}
 
 	// all rules
-	if extends[SpectralOpenAPI] == SpectralAll {
+	if extends[SpectralOpenAPI] == VacuumAll || extends[VacuumOpenAPI] == VacuumAll {
 		// suck in all rules
 		allRules := rsm.openAPIRuleSet
 		for k, v := range allRules.Rules {
@@ -168,7 +169,7 @@ func SniffOutAllExternalRules(
 	}
 
 	// no rules!
-	if extends[SpectralOpenAPI] == SpectralOff {
+	if extends[SpectralOpenAPI] == VacuumOff || extends[VacuumOpenAPI] == VacuumOff {
 		if rs.DocumentationURI == "" {
 			rs.DocumentationURI = "https://quobix.com/vacuum/rulesets/no-rules"
 		}

--- a/rulesets/rulesets_test.go
+++ b/rulesets/rulesets_test.go
@@ -63,7 +63,7 @@ func TestCreateRuleSetUsingJSON_Success(t *testing.T) {
 
 func TestRuleSet_GetExtendsValue_Single(t *testing.T) {
 
-	yaml := `extends: spectral:oas
+	yaml := `extends: vacuum:oas
 rules:
  fish-cakes:
    description: yummy sea food
@@ -78,7 +78,7 @@ rules:
 	assert.NoError(t, err)
 	assert.Len(t, rs.Rules, 1)
 	assert.NotNil(t, rs.GetExtendsValue())
-	assert.Equal(t, "spectral:oas", rs.GetExtendsValue()["spectral:oas"])
+	assert.Equal(t, "vacuum:oas", rs.GetExtendsValue()["vacuum:oas"])
 
 }
 
@@ -86,7 +86,7 @@ func TestRuleSet_GetExtendsValue_Multi(t *testing.T) {
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - recommended
 rules:
  fish-cakes:
@@ -102,14 +102,14 @@ rules:
 	assert.NoError(t, err)
 	assert.Len(t, rs.Rules, 1)
 	assert.NotNil(t, rs.GetExtendsValue())
-	assert.Equal(t, "recommended", rs.GetExtendsValue()["spectral:oas"])
+	assert.Equal(t, "recommended", rs.GetExtendsValue()["vacuum:oas"])
 
 }
 
 func TestRuleSet_GetExtendsValue_Multi_Noflag(t *testing.T) {
 
 	yaml := `extends:
-  - spectral:oas
+  - vacuum:oas
 rules:
  fish-cakes:
    description: yummy sea food
@@ -124,8 +124,8 @@ rules:
 	assert.NoError(t, err)
 	assert.Len(t, rs.Rules, 1)
 	assert.NotNil(t, rs.GetExtendsValue())
-	assert.Equal(t, "spectral:oas", rs.GetExtendsValue()["spectral:oas"])
-	assert.Equal(t, "spectral:oas", rs.GetExtendsValue()["spectral:oas"]) // idempotence state check.
+	assert.Equal(t, "vacuum:oas", rs.GetExtendsValue()["vacuum:oas"])
+	assert.Equal(t, "vacuum:oas", rs.GetExtendsValue()["vacuum:oas"]) // idempotence state check.
 
 }
 
@@ -145,7 +145,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Rec_OverrideNotFound(t *testing
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - recommended
 rules:
  soda-pop: "off"`
@@ -161,7 +161,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_OverrideNotFound(t *testing
 
 	yaml := fmt.Sprintf(`extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - off
 rules:
  soda-pop: "%s"`, model.SeverityWarn)
@@ -178,7 +178,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_All_OverrideNotFound(t *testing
 
 	yaml := fmt.Sprintf(`extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - all
 rules:
  soda-pop: "%s"`, model.SeverityWarn)
@@ -194,7 +194,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Rec_RemoveRule(t *testing.T) {
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - recommended
 rules:
  operation-success-response: "off"`
@@ -210,7 +210,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Rec_SeverityInfo(t *testing.T) 
 
 	yaml := fmt.Sprintf(`extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - recommended
 rules:
  operation-success-response: "%s"`, model.SeverityHint)
@@ -226,7 +226,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_EnableRules(t *testing.T) {
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - off
 rules:
  operation-success-response: true
@@ -245,7 +245,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_EnableRulesNotFound(t *test
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - off
 rules:
  chewy-dinner: true
@@ -263,7 +263,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_All_NewRule(t *testing.T) {
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - all
 rules:
  fish-cakes:
@@ -288,7 +288,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_All_NewRuleReplace(t *testing.T
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - all
 rules:
  info-contact:
@@ -313,7 +313,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_CustomRule(t *testing.T) {
 
 	yaml := `extends:
   -
-    - spectral:oas
+    - vacuum:oas
     - all
 rules:
  info-contact:
@@ -336,7 +336,7 @@ rules:
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Off_RuleCategory(t *testing.T) {
 
-	yaml := `extends: [[spectral:oas, off]]
+	yaml := `extends: [[vacuum:oas, off]]
 rules:
   check-title-is-exactly-this:
     description: Check the title of the spec is exactly, 'this specific thing'
@@ -363,7 +363,7 @@ rules:
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Oas_SpectralOwasp(t *testing.T) {
 
-	yaml := `extends: [[spectral:oas, all], [spectral:owasp, all]]`
+	yaml := `extends: [[vacuum:oas, all], [spectral:owasp, all]]`
 
 	def := BuildDefaultRuleSets()
 	rs, _ := CreateRuleSetFromData([]byte(yaml))
@@ -374,7 +374,7 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_Oas_SpectralOwasp(t *testing.T)
 
 func TestRuleSetsModel_GenerateRuleSetFromConfig_Oas_VacuumOwasp(t *testing.T) {
 
-	yaml := `extends: [[spectral:oas, all], [vacuum:owasp, all]]`
+	yaml := `extends: [[vacuum:oas, all], [vacuum:owasp, all]]`
 
 	def := BuildDefaultRuleSets()
 	rs, _ := CreateRuleSetFromData([]byte(yaml))
@@ -508,7 +508,7 @@ rules:
       field: title
       function: pattern
 `
-	yamlC := `extends: [[spectral:oas, recommended]]
+	yamlC := `extends: [[vacuum:oas, recommended]]
 rules:
   dong:
     description: dong
@@ -634,7 +634,7 @@ rules:
       field: title
       function: pattern
 `
-	yamlC := `extends: [[spectral:oas, recommended]]
+	yamlC := `extends: [[vacuum:oas, recommended]]
 rules:
   dong:
     description: dong

--- a/utils/lint_file_request.go
+++ b/utils/lint_file_request.go
@@ -39,4 +39,5 @@ type LintFileRequest struct {
 	Lock                     *sync.Mutex
 	Logger                   *slog.Logger
 	PipelineOutput           bool
+	ShowRules                bool
 }


### PR DESCRIPTION
Sets a new permanent (and official) `vacuum:oas` namespace for rulesets. **vacuum is the star of vacuum, not spectral**

However, the old `spectral:oas` namespace is still perfectly valid and can be used moving forward. It's backwards compatible. 

All the docs have been updated to use the new namespace.

Also tuned up the `--pipeline-output` command. 

Also a new official Github Action is available for vacuum as a part of the `v0.17` release. [Read the docs](https://quobix.com/vacuum/github-action/)
