### PR TITLE
enumeration rule handle slice of values, like spectral

### DIFF
--- a/functions/core/alphabetical_test.go
+++ b/functions/core/alphabetical_test.go
@@ -19,7 +19,7 @@ func TestAlphabetical_RunRule_FailStringArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -43,7 +43,7 @@ func TestAlphabetical_RunRule_PassStringArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -64,7 +64,7 @@ func TestAlphabetical_RunRule_FailIntegerArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -85,7 +85,7 @@ func TestAlphabetical_RunRule_FailFloatArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -106,7 +106,7 @@ func TestAlphabetical_RunRule_SuccessIntegerArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -127,7 +127,7 @@ func TestAlphabetical_RunRule_SuccessFloatArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -148,7 +148,7 @@ func TestAlphabetical_RunRule_IgnoreBooleanArray(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
@@ -175,7 +175,7 @@ func TestAlphabetical_RunRule_ObjectFail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["keyedBy"] = "nuggets"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
@@ -203,7 +203,7 @@ func TestAlphabetical_RunRule_ObjectSuccess(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["keyedBy"] = "heat"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
@@ -231,7 +231,7 @@ func TestAlphabetical_RunRule_ObjectIntegersSuccess(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["keyedBy"] = "heat"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
@@ -259,7 +259,7 @@ func TestAlphabetical_RunRule_ObjectIntegersFail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["keyedBy"] = "heat"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
@@ -287,7 +287,7 @@ func TestAlphabetical_RunRule_ObjectFailNoKeyedBy(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "alphabetical", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)

--- a/functions/core/casing_test.go
+++ b/functions/core/casing_test.go
@@ -16,7 +16,7 @@ func TestCasing_RunRule_CamelSuccess(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "camel"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -40,7 +40,7 @@ func TestCasing_RunRule_CamelFail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "camel"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -62,7 +62,7 @@ func TestCasing_RunRule_PascalSuccess(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "pascal"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -84,7 +84,7 @@ func TestCasing_RunRule_PascalFail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "pascal"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -107,7 +107,7 @@ func TestCasing_RunRule_KebabSuccess(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "kebab"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -130,7 +130,7 @@ func TestCasing_RunRule_KebabFail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "kebab"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -159,7 +159,7 @@ func TestCasing_RunRule_PascalKebabSuccess(t *testing.T) {
 		nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 		assert.Len(t, nodes, 1)
 
-		opts := make(map[string]string)
+		opts := make(map[string]any)
 		opts["type"] = "pascal-kebab"
 
 		rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -190,7 +190,7 @@ func TestCasing_RunRule_PascalKebabFail(t *testing.T) {
 		nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 		assert.Len(t, nodes, 1)
 
-		opts := make(map[string]string)
+		opts := make(map[string]any)
 		opts["type"] = "pascal-kebab"
 
 		rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -214,7 +214,7 @@ func TestCasing_RunRule_CobolSuccess(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "cobol"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -237,7 +237,7 @@ func TestCasing_RunRule_CobolFail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "cobol"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -260,7 +260,7 @@ func TestCasing_RunRule_SnakeSuccess(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -283,7 +283,7 @@ func TestCasing_RunRule_SnakeFail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -306,7 +306,7 @@ func TestCasing_RunRule_MacroSuccess(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "macro"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -329,7 +329,7 @@ func TestCasing_RunRule_MacroFail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "macro"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -352,7 +352,7 @@ func TestCasing_RunRule_CamelNoDigits_Success(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "camel"
 	opts["disallowDigits"] = "true"
 
@@ -376,7 +376,7 @@ func TestCasing_RunRule_CamelNoDigits_Fail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "camel"
 	opts["disallowDigits"] = "true"
 
@@ -400,7 +400,7 @@ func TestCasing_RunRule_Snake_SeparatingChar_Success(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 	opts["separator.char"] = ","
 
@@ -424,7 +424,7 @@ func TestCasing_RunRule_Snake_SeparatingChar_Fail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 	opts["separator.char"] = ","
 
@@ -448,7 +448,7 @@ func TestCasing_RunRule_Snake_AllowLeading_Success(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 	opts["separator.char"] = ","
 	opts["separator.allowLeading"] = "true"
@@ -473,7 +473,7 @@ func TestCasing_RunRule_Snake_AllowLeading_Fail(t *testing.T) {
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 	opts["separator.char"] = ","
 	opts["separator.allowLeading"] = "false"
@@ -491,7 +491,7 @@ func TestCasing_RunRule_Snake_AllowLeading_Fail(t *testing.T) {
 
 func TestCasing_GetSchema_Valid(t *testing.T) {
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "snake"
 
 	rf := &Casing{}
@@ -528,7 +528,7 @@ pork:
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 3, "expected 3 'properties' objects")
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "macro"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)
@@ -565,7 +565,7 @@ pork:
 	nodes, _ := gen_utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 3, "expected 3 'properties' objects")
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["type"] = "macro"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "casing", "", nil)

--- a/functions/core/core_test.go
+++ b/functions/core/core_test.go
@@ -2,7 +2,7 @@ package core
 
 import "github.com/daveshanley/vacuum/model"
 
-func buildCoreTestRule(given, severity, function, field string, functionOptions map[string]string) model.Rule {
+func buildCoreTestRule(given, severity, function, field string, functionOptions map[string]any) model.Rule {
 	return model.Rule{
 		Given:       given,
 		Severity:    severity,
@@ -15,7 +15,7 @@ func buildCoreTestRule(given, severity, function, field string, functionOptions 
 	}
 }
 
-func buildCoreTestContext(action *model.RuleAction, options map[string]string) model.RuleFunctionContext {
+func buildCoreTestContext(action *model.RuleAction, options map[string]any) model.RuleFunctionContext {
 	return model.RuleFunctionContext{
 		RuleAction: action,
 		Options:    options,

--- a/functions/core/enumeration.go
+++ b/functions/core/enumeration.go
@@ -4,13 +4,12 @@
 package core
 
 import (
-    "fmt"
-    "github.com/daveshanley/vacuum/model"
-    vacuumUtils "github.com/daveshanley/vacuum/utils"
-    "github.com/pb33f/doctor/model/high/v3"
-    "github.com/pb33f/libopenapi/utils"
-    "gopkg.in/yaml.v3"
-    "strings"
+	"fmt"
+	"github.com/daveshanley/vacuum/model"
+	vacuumUtils "github.com/daveshanley/vacuum/utils"
+	"github.com/pb33f/doctor/model/high/v3"
+	"gopkg.in/yaml.v3"
+	"strings"
 )
 
 // Enumeration is a rule that will check that a set of values meet the supplied 'values' supplied via functionOptions.
@@ -51,11 +50,23 @@ func (e Enumeration) RunRule(nodes []*yaml.Node, context model.RuleFunctionConte
 	message := context.Rule.Message
 
 	// check supplied values (required)
-	props := utils.ConvertInterfaceIntoStringMap(context.Options)
-	if props["values"] == "" {
+	m, ok := context.Options.(map[string]any)
+	if !ok {
 		return nil
 	}
-	values = strings.Split(props["values"], ",")
+	optValues, ok := m["values"]
+	if !ok {
+		return nil
+	}
+	switch value := optValues.(type) {
+	case string:
+		values = strings.Split(value, ",")
+	case []string:
+		values = []string{}
+		for i := range value {
+			values = append(values, value[i])
+		}
+	}
 
 	pathValue := "unknown"
 	if path, ok := context.Given.(string); ok {

--- a/functions/core/enumeration_test.go
+++ b/functions/core/enumeration_test.go
@@ -25,7 +25,7 @@ func TestEnumeration_RunRule_Success(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["values"] = "turkey, sprouts, presents, ham"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "", opts)
@@ -39,13 +39,53 @@ func TestEnumeration_RunRule_Success(t *testing.T) {
 	assert.Len(t, res, 0)
 }
 
+func TestEnumeration_RunRule_Array_Success(t *testing.T) {
+	sampleYaml := `christmas: "ham"`
+	path := "$.christmas"
+	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
+	assert.Len(t, nodes, 1)
+
+	opts := make(map[string]any)
+	opts["values"] = []string{"turkey", "sprouts", "presents", "ham", ",,,,,,,"}
+
+	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "", opts)
+	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
+	ctx.Given = path
+	ctx.Rule = &rule
+
+	def := &Enumeration{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 0)
+}
+
+func TestEnumeration_RunRule_Array_Fail(t *testing.T) {
+	sampleYaml := `christmas: "arguments"`
+	path := "$.christmas"
+	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
+	assert.Len(t, nodes, 1)
+
+	opts := make(map[string]any)
+	opts["values"] = []string{"turkey", "sprouts", "presents", "ham", ",,,,,,,"}
+
+	rule := buildCoreTestRule(path, model.SeverityError, "enumeration", "", opts)
+	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)
+	ctx.Given = path
+	ctx.Rule = &rule
+
+	def := &Enumeration{}
+	res := def.RunRule(nodes, ctx)
+
+	assert.Len(t, res, 1)
+}
+
 func TestEnumeration_RunRule_Fail(t *testing.T) {
 	sampleYaml := `christmas: "arguments"`
 	path := "$.christmas"
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["values"] = "turkey, sprouts, presents, ham"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "enumeration", "", opts)
@@ -65,7 +105,7 @@ func TestEnumeration_RunRule_FalseFail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string) // don't add opts.
+	opts := make(map[string]any) // don't add opts.
 
 	rule := buildCoreTestRule(path, model.SeverityError, "enumeration", "", opts)
 	ctx := buildCoreTestContextFromRule(model.CastToRuleAction(rule.Then), rule)

--- a/functions/core/length_test.go
+++ b/functions/core/length_test.go
@@ -46,7 +46,7 @@ paths:
 	drDocument := drModel.NewDrDocument(m)
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["min"] = "3"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "length", "paths", ops)
@@ -77,7 +77,7 @@ paths:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["min"] = "4"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "length", "paths", ops)
@@ -106,7 +106,7 @@ paths:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["min"] = "4"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "length", "paths", ops)
@@ -133,7 +133,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["min"] = "6"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "length", "tags", ops)
@@ -160,7 +160,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "2"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "length", "tags", ops)
@@ -189,7 +189,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "4"
 	ops["min"] = "2"
 
@@ -218,7 +218,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "3"
 	ops["min"] = "2"
 
@@ -247,7 +247,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "9"
 	ops["min"] = "2"
 
@@ -278,7 +278,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "9"
 	ops["min"] = "2"
 
@@ -307,7 +307,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "9"
 	ops["min"] = "3"
 
@@ -336,7 +336,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "1"
 	ops["min"] = "0"
 
@@ -363,7 +363,7 @@ tags:`
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "9"
 	ops["min"] = "2"
 
@@ -444,7 +444,7 @@ tags:
 
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 
-	ops := make(map[string]string)
+	ops := make(map[string]any)
 	ops["max"] = "1"
 	ops["min"] = "0"
 

--- a/functions/core/pattern_test.go
+++ b/functions/core/pattern_test.go
@@ -25,7 +25,7 @@ func TestPattern_RunRule_PatternMatchSuccess(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["match"] = "[abc]+"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "", opts)
@@ -64,7 +64,7 @@ func TestPattern_RunRule_PatternNotMatchError(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["notMatch"] = "[[abc)"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "carpet", opts)
@@ -85,7 +85,7 @@ func TestPattern_RunRule_PatternMatchFail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["match"] = "[abc]+"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "carpet", opts)
@@ -106,7 +106,7 @@ func TestPattern_RunRule_PatternMatchError(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["match"] = "([abc]"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "carpet", opts)
@@ -127,7 +127,7 @@ func TestPattern_RunRule_PatternNotMatchFail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["notMatch"] = `\w{3}\d`
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "pizza", opts)
@@ -149,7 +149,7 @@ func TestPattern_RunRule_UseFieldName(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["match"] = "cake"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "sleep", opts)
@@ -171,7 +171,7 @@ func TestPattern_RunRule_ContainMap(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["match"] = "until"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "sleep", opts)
@@ -193,7 +193,7 @@ func TestPattern_RunRule_Issue585(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["match"] = `^(?=.{1,19}$)[0-9]{0,18}(?:\\.[0-9]{0,2})?$`
 
 	rule := buildCoreTestRule(path, model.SeverityError, "pattern", "sleep", opts)

--- a/functions/core/xor_test.go
+++ b/functions/core/xor_test.go
@@ -49,7 +49,7 @@ func TestXor_RunRule_Success(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["properties"] = "sparkles, rainbows"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
@@ -74,7 +74,7 @@ func TestXor_RunRule_NoProps(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 
 	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
 	ctx := buildCoreTestContext(model.CastToRuleAction(rule.Then), opts)
@@ -98,7 +98,7 @@ func TestXor_RunRule_Fail(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["properties"] = "sparkles, shiny"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
@@ -123,7 +123,7 @@ func TestXor_RunRule_Fail_AllUndefined(t *testing.T) {
 	nodes, _ := utils.FindNodes([]byte(sampleYaml), path)
 	assert.Len(t, nodes, 1)
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["properties"] = "clouds, rain"
 
 	rule := buildCoreTestRule(path, model.SeverityError, "xor", "", opts)
@@ -139,7 +139,7 @@ func TestXor_RunRule_Fail_AllUndefined(t *testing.T) {
 
 func TestXor_GetSchema_Invalid_Min(t *testing.T) {
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["properties"] = ""
 
 	rf := &Xor{}
@@ -152,7 +152,7 @@ func TestXor_GetSchema_Invalid_Min(t *testing.T) {
 
 func TestXor_GetSchema_Invalid_Min_NotEnough(t *testing.T) {
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["properties"] = "notenough"
 
 	rf := &Xor{}
@@ -165,7 +165,7 @@ func TestXor_GetSchema_Invalid_Min_NotEnough(t *testing.T) {
 
 func TestXor_GetSchema_Invalid_Max(t *testing.T) {
 
-	opts := make(map[string]string)
+	opts := make(map[string]any)
 	opts["properties"] = "chip, chop, chap"
 
 	rf := &Xor{}


### PR DESCRIPTION
Previously, the rule only supported comma-separated strings for the option. Now, it accepts both a comma-separated string and a string array as valid input for the option. `values``values`
