### PR TITLE
fix: remove-max-properties in Enumerations

### DIFF
--- a/functions/core/enumeration.go
+++ b/functions/core/enumeration.go
@@ -27,7 +27,6 @@ func (e Enumeration) GetSchema() model.RuleFunctionSchema {
 			},
 		},
 		MinProperties: 1,
-		MaxProperties: 10,
 		ErrorMessage:  "'enumerate' needs 'values' to operate. A valid example of 'values' are: 'cake, egg, milk'",
 	}
 }


### PR DESCRIPTION
Hi there,

We've noticed a max prop for enumerations which is locking us to max 10 values and doesn't seem to make sense.
Cheers