### PR TITLE
Fix lsp publishDiagnostics null payload

### DIFF
--- a/language-server/server.go
+++ b/language-server/server.go
@@ -146,7 +146,8 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc, delay
 }
 
 func ConvertResultsIntoDiagnostics(result *motor.RuleSetExecutionResult) []protocol.Diagnostic {
-	var diagnostics []protocol.Diagnostic
+	diagnostics := []protocol.Diagnostic{}
+
 	for _, vacuumResult := range result.Results {
 		diagnostics = append(diagnostics, ConvertResultIntoDiagnostic(&vacuumResult))
 


### PR DESCRIPTION
With my previous PR (#705) I introduced a bug where the LSP client got incorrect diagnostic payload, the diagnostics list was null instead of empty list. I missed the detail in the `ConvertResultsIntoDiagnostics` function where the diagnostic list is initialized with a nil value implicitly instead of an empty list. This causes the JSON serializer to interpret the list as `null` instead of `[]`.

This pull request fixes the issue mentioned above. 