### PR TITLE
create category from ruleset if it doesn't exist

### DIFF
--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -405,6 +405,9 @@ func (rsm ruleSetsModel) GenerateRuleSetFromSuppliedRuleSetWithHTTPClient(rulese
 			} else {
 				if model.RuleCategories[rc.Id] != nil {
 					nr.RuleCategory = model.RuleCategories[rc.Id]
+				} else {
+					model.RuleCategories[rc.Id] = &rc
+					nr.RuleCategory = model.RuleCategories[rc.Id]
 				}
 			}
 

--- a/rulesets/rulesets_test.go
+++ b/rulesets/rulesets_test.go
@@ -58,7 +58,6 @@ func TestCreateRuleSetUsingJSON_Success(t *testing.T) {
 	rs, err := CreateRuleSetUsingJSON([]byte(json))
 	assert.NoError(t, err)
 	assert.Len(t, rs.Rules, 1)
-
 }
 
 func TestRuleSet_GetExtendsValue_Single(t *testing.T) {
@@ -267,6 +266,10 @@ func TestRuleSetsModel_GenerateRuleSetFromConfig_All_NewRule(t *testing.T) {
     - all
 rules:
  fish-cakes:
+   category:
+     id: snacks
+     name: snacks name
+     description: snacks description
    description: yummy sea food
    recommended: true
    type: style
@@ -281,6 +284,9 @@ rules:
 	assert.Len(t, newrs.Rules, totalRules+1)
 	assert.Equal(t, true, newrs.Rules["fish-cakes"].Recommended)
 	assert.Equal(t, "yummy sea food", newrs.Rules["fish-cakes"].Description)
+	assert.Equal(t, "snacks", newrs.Rules["fish-cakes"].RuleCategory.Id)
+	assert.Equal(t, "snacks name", newrs.Rules["fish-cakes"].RuleCategory.Name)
+	assert.Equal(t, "snacks description", newrs.Rules["fish-cakes"].RuleCategory.Description)
 
 }
 


### PR DESCRIPTION
I'm running into nil pointer panics when adding custom category values to custom rules.

minimal example config (using a custom category `consistency`):
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/daveshanley/vacuum/refs/heads/main/rulesets/schemas/ruleset.schema.json

extends:
  - [vacuum:oas, all]

rules:
  enums-should-be-strings:
    category:
      id: consistency
    description: Enums should be strings
    howToFix: Set the 'type' property to 'string' for all enum definitions
    id: enums-should-be-strings
    given: "$.components.schemas[?@.enum]"
    severity: warn
    message: Enums should have type 'string'
    then:
      field: type
      function: pattern
      functionOptions:
        match: "^string$"
```

When running vacuum lint with that rulset I get:
```
 version: unknown | compiled: Tue, 14 Oct 2025 17:59:54 UTC
 https://quobix.com/vacuum/ | https://github.com/daveshanley/vacuum

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x6f6a88]

goroutine 1 [running]:
github.com/daveshanley/vacuum/rulesets.ruleSetsModel.GenerateRuleSetFromSuppliedRuleSetWithHTTPClient({0x4000404e00, 0x40002caa00}, 0x400047f420, 0x0)
	/opt/vacuum/rulesets/rulesets.go:411 +0x34c8
github.com/daveshanley/vacuum/cmd.BuildRuleSetFromUserSuppliedSetWithHTTPClient({0x40006c2280?, 0x0?, 0x0?}, {0x15ecc18, 0x40002cad60}, 0x0)
	/opt/vacuum/cmd/shared_functions.go:46 +0xa8
github.com/daveshanley/vacuum/cmd.BuildRuleSetFromUserSuppliedLocation({0xffffd9a5df29?, 0xa73ac?}, {0x15ecc18, 0x40002cad60}, 0x0?, 0x0)
	/opt/vacuum/cmd/shared_functions.go:67 +0x124
github.com/daveshanley/vacuum/cmd.LoadRulesetWithConfig(0x40006c6000, 0x1a?)
	/opt/vacuum/cmd/lint_shared.go:268 +0xcc
github.com/daveshanley/vacuum/cmd.runLint(0x400048e908, {0x400066c810, 0x1, 0x3})
	/opt/vacuum/cmd/lint_cmd.go:146 +0x46c
github.com/spf13/cobra.(*Command).execute(0x400048e908, {0x400066c7b0, 0x3, 0x3})
	/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x400048e608)
	/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
github.com/daveshanley/vacuum/cmd.Execute()
	/opt/vacuum/cmd/root.go:27 +0x20
main.main()
	/opt/vacuum/vacuum.go:8 +0x1c
```

This PR adds the category to `RuleCategories` if it doesn't already exist, which resolves the nil pointer panic.
I updated an existing test which creates a rule rule to include a category to assert is created properly.