### PR TITLE
add lock appending to errors slice to fix race condition

### DIFF
--- a/motor/race_test.go
+++ b/motor/race_test.go
@@ -1,0 +1,76 @@
+package motor
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/daveshanley/vacuum/rulesets"
+)
+
+func TestConcurrentRuleExecution(t *testing.T) {
+	spec := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: OK
+  /another:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestSchema'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    TestSchema:
+      type: object
+      properties:
+        invalid_snake_case:
+          type: string
+        anotherInvalid_field:
+          type: integer
+    invalidCamelCase:
+      type: object
+      properties:
+        bad_naming:
+          type: string`
+
+	// Share the same ruleset across goroutines to trigger race condition
+	rs := rulesets.BuildDefaultRuleSets()
+	sharedRuleSet := rs.GenerateOpenAPIDefaultRuleSet()
+
+	const numGoroutines = 1000
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := range numGoroutines {
+		go func(id int) {
+			defer wg.Done()
+
+			// Add some variation to increase race potential
+			specVariation := spec + fmt.Sprintf(`
+    Schema%d:
+      type: object
+      properties:
+        field_%d:
+          type: string`, id, id)
+
+			ApplyRulesToRuleSet(&RuleSetExecution{
+				RuleSet:      sharedRuleSet, // Same ruleset shared across goroutines
+				Spec:         []byte(specVariation),
+				SpecFileName: fmt.Sprintf("test%d.yaml", id),
+			})
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -902,7 +902,9 @@ func runRule(ctx ruleContext, doneChan chan bool) {
 		}
 
 		if err != nil {
+			lock.Lock()
 			*ctx.errors = append(*ctx.errors, err)
+			lock.Unlock()
 			doneChan <- true
 			return
 		}


### PR DESCRIPTION
I'm running into an intermittent race condition issue using vacuum as a library where I'm calling `ApplyRulesToRuleSet` in my code, as the code I'm testing runs tests with the `-race` flag by default.

I created a unit test to hunt down the issue, run with: `go test -race ./motor -run TestConcurrentRuleExecution -v`

Just needs a lock around appending errors and that gets ride of the race.