### PR TITLE
add documentation url to rule struct

### DIFF
--- a/model/rules.go
+++ b/model/rules.go
@@ -113,6 +113,7 @@ type RuleAction struct {
 type Rule struct {
 	Id                 string         `json:"id,omitempty" yaml:"id,omitempty"`
 	Description        string         `json:"description,omitempty" yaml:"description,omitempty"`
+	DocumentationURL   string         `json:"documentationUrl,omitempty" yaml:"documentationUrl,omitempty"`
 	Message            string         `json:"message,omitempty" yaml:"message,omitempty"`
 	Given              interface{}    `json:"given,omitempty" yaml:"given,omitempty"`
 	Formats            []string       `json:"formats,omitempty" yaml:"formats,omitempty"`


### PR DESCRIPTION
You can set the `documentationUrl` on a rule but it's not available on the rule struct to then use in the results.

My use case for this is using vacuum as a library inside a custom CLI, and I want to be able to link to an internal API standards site for people to get more context on the rule if required.

Would also be the first (tiny) step towards enabling: https://github.com/daveshanley/vacuum/issues/416 (which I might come to look at in the next few days).