### PR TITLE
fix: language server diagnostics return empty list instead of null

### DIFF
--- a/language-server/server.go
+++ b/language-server/server.go
@@ -47,7 +47,7 @@ func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState 
 		lintRequest:   lintRequest,
 		documentStore: newDocumentStore(),
 	}
-	handler.Initialize = func(context *glsp.Context, params *protocol.InitializeParams) (interface{}, error) {
+	handler.Initialize = func(context *glsp.Context, params *protocol.InitializeParams) (any, error) {
 		if params.Trace != nil {
 			protocol.SetTraceValue(*params.Trace)
 		}
@@ -153,7 +153,7 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 }
 
 func ConvertResultsIntoDiagnostics(result *motor.RuleSetExecutionResult) []protocol.Diagnostic {
-	var diagnostics []protocol.Diagnostic
+	diagnostics := []protocol.Diagnostic{}
 
 	for _, vacuumResult := range result.Results {
 		diagnostics = append(diagnostics, ConvertResultIntoDiagnostic(&vacuumResult))


### PR DESCRIPTION
Hello, I noticed that I get an error when I try to edit an empty openapi.yaml file.

Specificly:
```stacktrace
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:214: attempt to get length of local 'diagnostics' (a nil value)

stack traceback:
        /usr/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:214: in function 'handle_diagnostics'
        /usr/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:240: in function 'handler'
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:1117: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This resulted from returning nil instead of an empty list as diagnostics.
As required by the specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#publishDiagnosticsParams

I also renamed interface{} to any. Since its the new style.