### PR TITLE
add more output to lsp message & open docs code action

### DIFF
--- a/tui/lint_details_table_render.go
+++ b/tui/lint_details_table_render.go
@@ -5,13 +5,12 @@ package tui
 
 import (
 	"fmt"
-	"os/exec"
-	"runtime"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/glamour"
 	"github.com/daveshanley/vacuum/color"
+	"github.com/daveshanley/vacuum/utils"
 	"github.com/muesli/termenv"
 )
 
@@ -330,20 +329,7 @@ func (m *ViolationResultTableModel) fetchDocumentation(ruleID string) tea.Cmd {
 		// If it's not the default quobix.com pattern, open in browser
 		if !strings.Contains(customURL, "quobix.com/vacuum/rules/") {
 			return func() tea.Msg {
-				// Open URL in default browser
-				var cmd *exec.Cmd
-				switch runtime.GOOS {
-				case "linux":
-					cmd = exec.Command("xdg-open", customURL)
-				case "windows":
-					cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", customURL)
-				case "darwin":
-					cmd = exec.Command("open", customURL)
-				default:
-					return docsErrorMsg{ruleID: ruleID, err: "Unsupported platform for opening browser", is404: false}
-				}
-				
-				if err := cmd.Start(); err != nil {
+				if err := utils.OpenURL(customURL); err != nil {
 					return docsErrorMsg{ruleID: ruleID, err: fmt.Sprintf("Failed to open browser: %s", err.Error()), is404: false}
 				}
 				

--- a/utils/open_url.go
+++ b/utils/open_url.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// OpenURL opens the given URL in the system's default browser
+func OpenURL(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}


### PR DESCRIPTION
When using the language server it would be nice to have a bit more of the rule detail in the diagnostic message, most importantly the how to fix.

This change adds more detail if those fields exist on the rule.

Example in using vacuum in neovim:

* **Before:**
<img width="1104" height="151" alt="Screenshot 2025-10-29 at 10 05 40" src="https://github.com/user-attachments/assets/988bac1c-397f-4c18-9f3e-00e13f4d5493" />


* **After:**
<img width="1012" height="280" alt="Screenshot 2025-10-29 at 10 43 25" src="https://github.com/user-attachments/assets/33ed6dea-8289-4079-8a63-34da50a1845f" />
(note the duplicate rule id comes from how the lsp client is displaying the message, in some mechanisms you don't see the rule id in square brackets so having it included in the message ensures it's always visible, but can be removed if there is an issue with the doubling up in some cases)


Also adds a code action to open the documentation url for a rule, so people can easily view the docs for anything flagged. This uses the same open browser approach as added to the tui for custom documentation urls, so I moved that into a util so it can be used in both places.

Now when you hover over a diagnostic you can open the docs directly.