### PR TITLE
fix disabling of non oas rulesets with individual extending

### DIFF
--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -363,8 +363,10 @@ func (rsm ruleSetsModel) GenerateRuleSetFromSuppliedRuleSetWithHTTPClient(rulese
 				if rsm.openAPIRuleSet.Rules[k] != nil {
 					rs.Rules[k] = rsm.openAPIRuleSet.Rules[k]
 				} else {
-					// Check if it's an OWASP rule when vacuum:all is used
-					if extends[VacuumAllRulesets] == VacuumOff || extends[VacuumAllRulesets] == VacuumAll || extends[VacuumAllRulesets] == VacuumAllRulesets {
+					// Check if it's an OWASP rule when vacuum:all or vacuum:owasp is used
+					if extends[VacuumAllRulesets] == VacuumOff || extends[VacuumAllRulesets] == VacuumAll || extends[VacuumAllRulesets] == VacuumAllRulesets ||
+						extends[VacuumOwasp] == VacuumOff || extends[VacuumOwasp] == VacuumAll || extends[VacuumOwasp] == VacuumRecommended ||
+						extends[SpectralOwasp] == VacuumOff || extends[SpectralOwasp] == VacuumAll || extends[SpectralOwasp] == VacuumRecommended {
 						allOWASPRules := GetAllOWASPRules()
 						if allOWASPRules[k] != nil {
 							rs.Rules[k] = allOWASPRules[k]


### PR DESCRIPTION
I'm trying to use the extends, off syntax as described here: https://quobix.com/vacuum/rulesets/no-rules/

To enable a single `owasp` rule in my config, but that doesn't seem to work.

If I import them as `all` I can then disable each rule except the one I want but would be nice for the `off` approach to work with the other builtins, so I updated extends check and added a unit test to cover this specific case.

Minimal example to reproduce:

Spec:
```yaml
openapi: 3.0.0
info:
  title: Test API
  version: 1.0.0
paths: {}
components:
  schemas:
    TestSchema:
      type: object
      properties:
        id:
          type: integer
```

rules:
```yaml
extends:
  - [vacuum:oas, all]
  - [vacuum:owasp, off]

rules:
  # Enable only the OWASP integer format rule
  owasp-integer-format: true

```

Steps to reproduce:
1. run `vacuum lint -r test-ruleset.yaml test-spec.yaml`
2. Observe the warn about `owasp-integer-format` not existing and the issue is not reported.
3. Build with these changes.
4. Run `vacuum lint -r test-ruleset.yaml test-spec.yaml` again and observe no warn about rule, and owasp issue is correctly reported.