### PR TITLE
enable dynamic file based ruleset selection in language server

### DIFF
--- a/language-server/server.go
+++ b/language-server/server.go
@@ -161,7 +161,7 @@ func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState 
 // This allows you to determine specifically what rules should be applied per spec, e.g.:
 // 
 // Have different teams which require different rules?
-// Check the value of info.contact.name in the spec and return the releant rules for that team.
+// Check the value of info.contact.name in the spec and return the relevant rules for that team.
 // 
 // Want to enable OWASP rules for only a specific server?
 // Check the value of servers[0].url and return the rules including the OWASP ruleset


### PR DESCRIPTION
This usecase _might_ be on the more niche side, but the code to achieve it is very minimal and it adds some pretty cool  possibilities to anyone using vacuum as a library (the detail in this PR description is longer than the actual code changes themselves).

> [!NOTE]  
> **high level summary**
> This lets you configure a custom function to pass to the language server to determine what rule set should be loaded based on the document content.

My scenario I have is I want to configure different rulesets based on the spec content. 
So we have an indicator in the spec that tell us this specific spec should be using a stricter ruleset and we dynamically enable additional rules. This means teams get the feedback of the ruleset relevant to them without needing to remember any additional flags to pass to the lint command it all just works automatically.

This works with linting out of the box, because we can parse the spec directly, however as we don't have the document content when starting the lsp sever we can't currently support this dynamic rulset approach.

So, this pull request adds `NewServerWithRulesetSelector` which wraps `NewServer` and lets you pass in a custom function to select the ruleset based on the generic `DocumentContext`.

So then in my wrapper of the language server I have a ruleset selector function which handles parsing the spec and looking for the indicator to determine which ruleset should be used.


```go		
func rulesetSelector(
	ctx context.Context,
	client httpclient.Client,
	rulesDir string,
) func(*languageserver.DocumentContext) *rulesets.RuleSet {
	return func(docCtx *languageserver.DocumentContext) *rulesets.RuleSet {
		config := linter.NewConfig(client, docCtx.Filename, model.SeverityError)
		config.Contents = docCtx.Content

		if err := config.LoadRulesetFromCacheFile(ctx, rulesDir); err != nil {
			return rulesets.BuildDefaultRuleSets().GenerateOpenAPIDefaultRuleSet()
		}

		return config.GenerateCompleteRuleSet(log.Logger)
	}
}
```

This is using code defined in my project, but the basic approach you see here is to:
1. is to configure the standard linter config
2. try and load the ruleset file from the cache (this function parses the file content to determine which ruleset to load)
3. fall back to using defaults if that errors

Using it like this:
```go
languageserver.NewServerWithRulesetSelector(
	fmt.Sprintf("%s-%s", ReleaseName, Version),
	&lfr,
	rulesetSelector(ctx, client, rulesDir),
).Run()

```

Any now I get the relevant ruleset loaded for my spec out of the box no flags or config changes required.