### PR TITLE
enable auto fixing via language server

### DIFF
--- a/cmd/language_server.go
+++ b/cmd/language_server.go
@@ -11,6 +11,7 @@ import (
 
 	languageserver "github.com/daveshanley/vacuum/language-server"
 	"github.com/daveshanley/vacuum/logging"
+	"github.com/daveshanley/vacuum/model"
 	"github.com/daveshanley/vacuum/rulesets"
 	"github.com/daveshanley/vacuum/utils"
 	"github.com/spf13/cobra"
@@ -111,6 +112,7 @@ IDE and start linting your OpenAPI documents in real-time.`,
 				DefaultRuleSets:          defaultRuleSets,
 				SelectedRS:               selectedRS,
 				Functions:                customFunctions,
+				AutoFixFunctions:         make(map[string]model.AutoFixFunction),
 				TimeoutFlag:              timeoutFlag,
 				LookupTimeoutFlag:        lookupTimeoutFlag,
 				IgnoreArrayCircleRef:     ignoreArrayCircleRef,

--- a/language-server/server_test.go
+++ b/language-server/server_test.go
@@ -1,0 +1,69 @@
+package languageserver
+
+import (
+	"testing"
+
+	"github.com/daveshanley/vacuum/model"
+	"github.com/daveshanley/vacuum/rulesets"
+	"github.com/daveshanley/vacuum/utils"
+	"github.com/stretchr/testify/assert"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	"go.yaml.in/yaml/v4"
+)
+
+func TestApplyAutoFix(t *testing.T) {
+	lintRequest := &utils.LintFileRequest{
+		SelectedRS: &rulesets.RuleSet{
+			Rules: map[string]*model.Rule{
+				"test-rule": {
+					AutoFixFunction: "mockAutoFix",
+				},
+			},
+		},
+		AutoFixFunctions: map[string]model.AutoFixFunction{
+			"mockAutoFix": func(node *yaml.Node, document *yaml.Node, context *model.RuleFunctionContext) (*yaml.Node, error) {
+				return node, nil
+			},
+		},
+	}
+
+	server := &ServerState{
+		lintRequest:   lintRequest,
+		documentStore: newDocumentStore(),
+	}
+
+	doc := &Document{
+		URI:     "file:///test.yaml",
+		Content: "test: value",
+	}
+
+	testRange := protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 0},
+		End:   protocol.Position{Line: 0, Character: 4},
+	}
+
+	fixedText, _ := server.applyAutoFix(doc, "test-rule", testRange)
+
+	assert.NotEmpty(t, fixedText, "Expected non-empty result from applyAutoFix")
+}
+
+func TestHasAutoFixForRule(t *testing.T) {
+	lintRequest := &utils.LintFileRequest{
+		SelectedRS: &rulesets.RuleSet{
+			Rules: map[string]*model.Rule{
+				"with-autofix": {AutoFixFunction: "testFunc"},
+				"no-autofix":   {AutoFixFunction: ""},
+			},
+		},
+		AutoFixFunctions: map[string]model.AutoFixFunction{
+			"testFunc": func(*yaml.Node, *yaml.Node, *model.RuleFunctionContext) (*yaml.Node, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	server := &ServerState{lintRequest: lintRequest}
+
+	assert.True(t, server.hasAutoFixForRule("with-autofix"), "Should have autofix for rule with autofix function")
+	assert.False(t, server.hasAutoFixForRule("no-autofix"), "Should not have autofix for rule without autofix function")
+}

--- a/utils/lint_file_request.go
+++ b/utils/lint_file_request.go
@@ -37,6 +37,7 @@ type LintFileRequest struct {
 	DefaultRuleSets          rulesets.RuleSets
 	SelectedRS               *rulesets.RuleSet
 	Functions                map[string]model.RuleFunction
+	AutoFixFunctions         map[string]model.AutoFixFunction
 	Lock                     *sync.Mutex
 	Logger                   *slog.Logger
 	PipelineOutput           bool


### PR DESCRIPTION
Now auto fixing is in place, we can apply the auto fixes via a code action in the language server 🎉 

https://github.com/user-attachments/assets/c7155238-3c03-4f02-88e9-0138f266cb27

> [!NOTE]
> tested in `neovim` and `VSCode`.
>
> I don't have many auto fix functions in place yet so the testing on what it can do has been limited, but as we adopt more in my code base I will fix any issues that come up.

## Approach

If a rule has and autofix function defined the lsp will show a quick fix item to apply that rule.
Getting that rule id didn't seem to work referencing directly from the diagnostic, I could not work out why so we read it from the diagnostic message and I added a comment to the code about that.

When the quick fix is applied, it will replace the highlighed diagnostic text with the replacement (as seen i the screen recording changing `enum` to `x-extensible-enum`.

(and next up I'm going to add applying the autofixes via the TUI)