### PR TITLE
fix no-style in bundle command

### DIFF
--- a/color/terminal_colors.go
+++ b/color/terminal_colors.go
@@ -674,6 +674,7 @@ func DisableColors() {
 	ASCIIBlue = ""
 	ASCIIYellow = ""
 	ASCIIGreen = ""
+	ASCIIGreenBold = ""
 	ASCIILightGreyItalic = ""
 	ASCIIBold = ""
 	ASCIIItalic = ""


### PR DESCRIPTION
fixes #758 

The `ASCIIGreenBold` color used in the header output was not disabled when the other color options are.