### PR TITLE
fix(cmd): ext-refs flag for bundle

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -107,7 +107,7 @@ func GetBundleCommand() *cobra.Command {
 				ExtractRefsSequentially: true,
 				Logger:                  logger,
 				AllowRemoteReferences:   remoteFlag,
-				ExcludeExtensionRefs:    extensionRefsFlag,
+				ExcludeExtensionRefs:    !extensionRefsFlag,
 			}
 
 			var bundled []byte


### PR DESCRIPTION
The `bundle` command compared to other commands passes the `ext-refs` flag (which should **enable** references resolution in extensions) to ExcludeExtensionRefs. That means that the flag needs to be negated. The flag being `true` means `ExcludeExtensionRefs` should be `false` and vice versa.

This is a breaking change. The alternative would be to move this flag into individual commands as each command would have different default to maintain current behavior.