### PR TITLE
Add help command to Makefile and fix typo in component description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
-build:
+.PHONY: help build run
+
+.DEFAULT_GOAL := help
+
+help: ## Display this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the vacuum binary to bin/vacuum
 	@go build -o bin/vacuum
 
-run:
+run: ## Run vacuum directly with go run
 	@go run vacuum.go

--- a/rulesets/rule_fixes.go
+++ b/rulesets/rule_fixes.go
@@ -59,7 +59,7 @@ const (
 		"then it won't be something you copy and paste. Please don't duplicate descriptions, make them deliberate and meaningful."
 
 	componentDescriptionFix string = "Components are the inputs and outputs of a specification. A user needs to be able to " +
-		"understand each component and what id does. Descriptions are critical to understanding components. Add a description!"
+		"understand each component and what it does. Descriptions are critical to understanding components. Add a description!"
 
 	oasServersFix string = "Ensure server URIs are correct and valid, check the schemes, ensure descriptions are complete."
 


### PR DESCRIPTION
## Summary
- Added help target to Makefile with automatic target discovery and formatting
- Made help the default target when running `make` without arguments
- Added descriptions to existing build and run targets
- Fixed typo in `componentDescriptionFix`: "what id does" → "what it does"

## Test plan
- Run `make` or `make help` to see the formatted help output
- Run `make build` and `make run` to verify existing targets still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)