### PR TITLE
fix nil panic in examples missing using x-exensible-enum

### DIFF
--- a/functions/openapi/examples_missing.go
+++ b/functions/openapi/examples_missing.go
@@ -13,6 +13,7 @@ import (
 	vacuumUtils "github.com/daveshanley/vacuum/utils"
 	"github.com/pb33f/doctor/model/high/v3"
 	"github.com/pb33f/libopenapi/datamodel/high"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
 	"github.com/pb33f/libopenapi/index"
 	"go.yaml.in/yaml/v4"
 )
@@ -101,7 +102,8 @@ func (em ExamplesMissing) RunRule(_ []*yaml.Node, context model.RuleFunctionCont
 				}
 
 				if p.SchemaProxy.Schema.Value.Items != nil && p.SchemaProxy.Schema.Value.Items.IsA() && p.SchemaProxy.Schema.Value.Items.A != nil {
-					if len(p.SchemaProxy.Schema.Value.Items.A.Schema().Enum) > 0 {
+					schema := p.SchemaProxy.Schema.Value.Items.A.Schema()
+					if schema != nil && (len(schema.Enum) > 0 || hasExtensibleEnum(schema)) {
 						continue
 					}
 				}
@@ -176,7 +178,8 @@ func (em ExamplesMissing) RunRule(_ []*yaml.Node, context model.RuleFunctionCont
 				}
 
 				if h.Schema.Schema.Value.Items != nil && h.Schema.Schema.Value.Items.IsA() && h.Schema.Schema.Value.Items.A != nil {
-					if len(h.Schema.Schema.Value.Items.A.Schema().Enum) > 0 {
+					schema := h.Schema.Schema.Value.Items.A.Schema()
+					if schema != nil && (len(schema.Enum) > 0 || hasExtensibleEnum(schema)) {
 						continue
 					}
 				}
@@ -337,7 +340,8 @@ func (em ExamplesMissing) RunRule(_ []*yaml.Node, context model.RuleFunctionCont
 			}
 
 			if s.Value.Items != nil && s.Value.Items.IsA() && s.Value.Items.A != nil {
-				if s.Value.Items.A.Schema() != nil && len(s.Value.Items.A.Schema().Enum) > 0 {
+				schema := s.Value.Items.A.Schema()
+				if schema != nil && (len(schema.Enum) > 0 || hasExtensibleEnum(schema)) {
 					continue
 				}
 			}
@@ -543,7 +547,8 @@ func checkParent(s any, depth int) bool {
 					}
 
 					if pp.Value.Items != nil && pp.Value.Items.IsA() && pp.Value.Items.A != nil {
-						if len(pp.Value.Items.A.Schema().Enum) > 0 {
+						schema := pp.Value.Items.A.Schema()
+						if schema != nil && (len(schema.Enum) > 0 || hasExtensibleEnum(schema)) {
 							return true
 						}
 					}
@@ -620,6 +625,23 @@ func isSchemaEnum(schema *v3.Schema) bool {
 	}
 	if len(schema.Value.Enum) > 0 {
 		return true
+	}
+	if schema.Value != nil {
+		return hasExtensibleEnum(schema.Value)
+	}
+	return false
+}
+func hasExtensibleEnum(schema *base.Schema) bool {
+	if schema == nil {
+		return false
+	}
+	lowSchema := schema.GoLow()
+	if lowSchema != nil && lowSchema.Extensions != nil {
+		for ext := lowSchema.Extensions.First(); ext != nil; ext = ext.Next() {
+			if ext.Key().Value == "x-extensible-enum" {
+				return true
+			}
+		}
 	}
 	return false
 }


### PR DESCRIPTION
I've run into an edgcasey nil panic scenario, where bundling with `composed` for a spec that uses `x-extensible-enum` rather than `enum` causes a nil pointer panic as the examples missing rule tries to reference `enum`.

## Minimal spec
```yaml
openapi: 3.0.0
info:
  title: Minimal Panic Test
  version: 1.0.0
paths:
  /test:
    get:
      parameters:
        - name: codes
          in: query
          schema:
            type: array
            items:
              $ref: '#/components/schemas/RefToExtensible'
      responses:
        '200':
          description: Success
components:
  schemas:
    RefToExtensible:
      $ref: '#/components/schemas/StatusCode'
    StatusCode:
      type: string
      x-extensible-enum:
        - active
        - inactive
```
## Steps
1. `vacuum bundle --composed minimal-spec.yaml bundled.yaml`
2. `vacuum lint bundled.yaml`
3. Observe panic.


## Notes
I've added an explicit check for `x-extensible-enum` in this scenario to fix the underlying panic, but there might be other places that could use similar checks. I'll do a review of those separately, raising this one on it's own to fix the scenario one of our teams is running into.
