### PR TITLE
fix(functions): checkPolymorphicProperty

### DIFF
--- a/functions/openapi/schema_type_test.go
+++ b/functions/openapi/schema_type_test.go
@@ -3273,6 +3273,26 @@ components:
 			expectedErrors: []struct{ message, path string }{},
 		},
 		{
+			name: "PropertyInAllOfNestedRef",
+			yaml: `openapi: 3.0.3
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+      discriminator:
+        propertyName: petType
+    PetBase:
+      allOf:
+        - type: object
+          properties:
+            petType:
+              type: string
+            name:
+              type: string`,
+			expectedErrors: []struct{ message, path string }{},
+		},
+		{
 			name: "PropertyInOneOf",
 			yaml: `openapi: 3.0.3
 components:
@@ -3444,4 +3464,3 @@ components:
 	assert.Contains(t, res[0].Message, "minimum")
 	assert.Contains(t, res[0].Message, "null")
 }
-


### PR DESCRIPTION
checkPolymorphicProperty correctly checked anyOf/oneOf/allOf but only one level deep and didn't respect `$ref`. This fixes the code to recursively descend down the schemas and respect references to ensure that all properties, even if not directly defined on the object, are found.