### PR TITLE
Invert PathItemReferences rule to validate $ref usage in operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ vacuum now supports both [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535) JSON
 There is a new command `generate-ignorefile` that will generate an ignore file from a linting report.
 
 New rule `no-request-body` checks for incorrect request bodies in operations, and `path-item-refs` checks for
-$refs being used in path items.
+$refs being incorrectly used on operations within path items (only the path item itself may use $ref).
 
 ---
 

--- a/functions/openapi/path_item_ref_test.go
+++ b/functions/openapi/path_item_ref_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestPathItemRef_RunRule_AllParamsInTop(t *testing.T) {
+func TestPathItemRef_RunRule_RefOnPathItem_Valid(t *testing.T) {
 
 	yml := `openapi: 3.1.0
 paths:
@@ -32,7 +32,41 @@ pops:
 
 	drDocument := drModel.NewDrDocument(m)
 
-	rule := buildOpenApiTestRuleAction(path, "path_parameters", "", nil)
+	rule := buildOpenApiTestRuleAction(path, "pathItemReferences", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Document = document
+	ctx.DrDocument = drDocument
+	ctx.Rule = &rule
+
+	def := PathItemReferences{}
+	res := def.RunRule(nil, ctx)
+
+	assert.Len(t, res, 0, "$ref on a path item is valid and should not be flagged")
+}
+
+func TestPathItemRef_RunRule_RefOnOperation_Invalid(t *testing.T) {
+
+	yml := `openapi: 3.1.0
+paths:
+  /pizza:
+    get:
+      $ref: "#/components/operations/GetPizza"
+components:
+  operations:
+    GetPizza:
+      description: get a pizza`
+
+	path := "$"
+
+	document, err := libopenapi.NewDocument([]byte(yml))
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+	m, _ := document.BuildV3Model()
+
+	drDocument := drModel.NewDrDocument(m)
+
+	rule := buildOpenApiTestRuleAction(path, "pathItemReferences", "", nil)
 	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
 	ctx.Document = document
 	ctx.DrDocument = drDocument
@@ -42,7 +76,51 @@ pops:
 	res := def.RunRule(nil, ctx)
 
 	assert.Len(t, res, 1)
-	assert.Equal(t, "path `/pizza/{type}/{topping}` item uses a $ref, it's technically allowed, but not a great idea", res[0].Message)
-	assert.Equal(t, "$.paths['/pizza/{type}/{topping}']", res[0].Path)
+	assert.Contains(t, res[0].Message, "GET")
+	assert.Contains(t, res[0].Message, "/pizza")
+	assert.Equal(t, "$.paths['/pizza'].get", res[0].Path)
+}
 
+func TestPathItemRef_RunRule_NoRef_NoResults(t *testing.T) {
+
+	yml := `openapi: 3.1.0
+paths:
+  /pizza:
+    get:
+      description: get a pizza
+    post:
+      description: create a pizza`
+
+	path := "$"
+
+	document, err := libopenapi.NewDocument([]byte(yml))
+	if err != nil {
+		panic(fmt.Sprintf("cannot create new document: %e", err))
+	}
+	m, _ := document.BuildV3Model()
+
+	drDocument := drModel.NewDrDocument(m)
+
+	rule := buildOpenApiTestRuleAction(path, "pathItemReferences", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Document = document
+	ctx.DrDocument = drDocument
+	ctx.Rule = &rule
+
+	def := PathItemReferences{}
+	res := def.RunRule(nil, ctx)
+
+	assert.Len(t, res, 0, "inline operations should not be flagged")
+}
+
+func TestPathItemRef_RunRule_NilDrDocument(t *testing.T) {
+
+	rule := buildOpenApiTestRuleAction("$", "pathItemReferences", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	ctx.Rule = &rule
+
+	def := PathItemReferences{}
+	res := def.RunRule(nil, ctx)
+
+	assert.Len(t, res, 0, "nil DrDocument should return no results")
 }

--- a/rulesets/rule_fixes.go
+++ b/rulesets/rule_fixes.go
@@ -40,7 +40,7 @@ const (
 
 	oas3HostNotExampleFix string = "Remove 'example.com from the 'servers' URL, it's not going to work."
 
-	PathItemReferencesFix string = "Path items should not use references for defining operations. It's technically allowed, but not great style"
+	PathItemReferencesFix string = "Operations within path items should not use $ref. If you need to reference a reusable definition, use $ref at the path item level instead"
 
 	oas2HostTrailingSlashFix string = "Remove the trailing slash from the host URL. This may cause some tools to incorrectly " +
 		"add a double slash to paths."

--- a/rulesets/ruleset_functions.go
+++ b/rulesets/ruleset_functions.go
@@ -1371,19 +1371,20 @@ func GetNoRequestBodyRule() *model.Rule {
 	}
 }
 
-// GetPathItemReferencesRule will check that path items have not used references, as they are not allowed.
+// GetPathItemReferencesRule will check that operations within path items have not used references.
+// $ref is only valid directly on the path item object itself, not on individual operations.
 func GetPathItemReferencesRule() *model.Rule {
 	return &model.Rule{
-		Name:         "Check path items have not used references",
+		Name:         "Check operations within path items have not used references",
 		Id:           PathItemReferences,
 		Formats:      model.OAS3AllFormat,
-		Description:  "Path items should not use references ($ref) values. They are technically not allowed.",
+		Description:  "Operations within path items should not use $ref values. $ref is only valid directly on the path item object itself.",
 		Given:        "$",
 		Resolved:     false,
 		RuleCategory: model.RuleCategories[model.CategoryOperations],
 		Recommended:  true,
 		Type:         Validation,
-		Severity:     model.SeverityInfo,
+		Severity:     model.SeverityWarn,
 		Then: model.RuleAction{
 			Function: "pathItemReferences",
 		},


### PR DESCRIPTION
Updated the PathItemReferences rule to ensure that $ref is not used within operations of path items, as it is only valid at the path item level. Added new tests to cover valid and invalid scenarios for $ref usage in operations, and improved documentation for clarity.