### PR TITLE
partially add origin field

### DIFF
--- a/functions/openapi/examples_schema.go
+++ b/functions/openapi/examples_schema.go
@@ -98,6 +98,7 @@ func (es ExamplesSchema) RunRule(_ []*yaml.Node, ruleContext model.RuleFunctionC
 			EndNode:   vacuumUtils.BuildEndNode(key),
 			Path:      path,
 			Rule:      ruleContext.Rule,
+			Origin:    ruleContext.Index.GetRolodex().FindNodeOrigin(node),
 		}
 
 		// set the Paths array if we found multiple locations

--- a/functions/openapi/operation_descriptions.go
+++ b/functions/openapi/operation_descriptions.go
@@ -73,6 +73,7 @@ func (od OperationDescription) RunRule(nodes []*yaml.Node, context model.RuleFun
 					Char: endNode.Column,
 				},
 			},
+			Origin: context.Index.GetRolodex().FindNodeOrigin(node),
 		}
 		component.AddRuleFunctionResult(v3.ConvertRuleResult(&result))
 		return result

--- a/functions/openapi/parameter_description.go
+++ b/functions/openapi/parameter_description.go
@@ -57,6 +57,7 @@ func (pd ParameterDescription) runRuleWithDrDocument(context model.RuleFunctionC
 			EndNode:   vutils.BuildEndNode(node),
 			Path:      path,
 			Rule:      context.Rule,
+			Origin:    context.Index.GetRolodex().FindNodeOrigin(node),
 		}
 		if len(paths) > 1 {
 			result.Paths = paths
@@ -164,6 +165,7 @@ func (pd ParameterDescription) runRuleWithIndex(nodes []*yaml.Node,
 				EndNode:   vutils.BuildEndNode(param.Node),
 				Path:      fmt.Sprintf("$.components.parameters['%s']", id),
 				Rule:      context.Rule,
+				Origin:    context.Index.GetRolodex().FindNodeOrigin(param.Node),
 			})
 		}
 	}
@@ -185,6 +187,7 @@ func (pd ParameterDescription) runRuleWithIndex(nodes []*yaml.Node,
 								EndNode:   vutils.BuildEndNode(param.Node),
 								Path:      pathString,
 								Rule:      context.Rule,
+								Origin:    context.Index.GetRolodex().FindNodeOrigin(param.Node),
 							})
 						}
 					}

--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -180,8 +180,6 @@ func ruleUsesFunction(rule *model.Rule, funcName string) bool {
 	return false
 }
 
-
-
 // ApplyRulesToRuleSet is a replacement for ApplyRules. This function was created before trying to use
 // vacuum as an API. The signature is not sufficient, but is embedded everywhere. This new method
 // uses a message structure, to allow the signature to grow, without breaking anything.
@@ -715,6 +713,7 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 			EndNode:   vacuumUtils.BuildEndNode(er.Node),
 			Message:   er.Error(),
 			Path:      er.Path,
+			Origin:    rolodexUnresolved.FindNodeOrigin(er.Node),
 		}
 		if res.StartNode == nil {
 			res.StartNode = utils.CreateStringNode("")
@@ -774,6 +773,7 @@ func ApplyRulesToRuleSet(execution *RuleSetExecution) *RuleSetExecutionResult {
 				EndNode:   vacuumUtils.BuildEndNode(idxError.KeyNode),
 				Message:   idxError.Error(),
 				Path:      idxError.Path,
+				Origin:    rolodexUnresolved.FindNodeOrigin(idxError.Node),
 			}
 			if res.StartNode == nil {
 				res.StartNode = utils.CreateStringNode("")


### PR DESCRIPTION
Added the `origin` field to the rule result to output the correct file when working with a multi-file spec

@daveshanley Is there a smarter way to avoid adding this field to every RuleFunctionResult?