### PR TITLE
Fix issue #829

### DIFF
--- a/functions/openapi/migrate_zally_ignore.go
+++ b/functions/openapi/migrate_zally_ignore.go
@@ -37,9 +37,10 @@ func (m MigrateZallyIgnore) RunRule(
 	// pre-allocate path segments slice; push/pop pattern avoids per-recursion allocations
 	segs := make([]string, 0, 32)
 	segs = append(segs, "$")
+	visited := make(map[*yaml.Node]bool)
 
 	for _, node := range nodes {
-		m.checkNodeWithPath(node, segs, &results, context)
+		m.checkNodeWithPath(node, segs, &results, context, visited)
 	}
 
 	return results
@@ -69,15 +70,20 @@ func (m MigrateZallyIgnore) checkNodeWithPath(
 	segs []string,
 	results *[]model.RuleFunctionResult,
 	context model.RuleFunctionContext,
+	visited map[*yaml.Node]bool,
 ) {
 	if node == nil {
 		return
 	}
+	if visited[node] {
+		return
+	}
+	visited[node] = true
 
 	switch node.Kind {
 	case yaml.DocumentNode:
 		for _, content := range node.Content {
-			m.checkNodeWithPath(content, segs, results, context)
+			m.checkNodeWithPath(content, segs, results, context, visited)
 		}
 	case yaml.MappingNode:
 		for i := 0; i < len(node.Content); i += 2 {
@@ -96,14 +102,14 @@ func (m MigrateZallyIgnore) checkNodeWithPath(
 				})
 			}
 
-			m.checkNodeWithPath(valueNode, segs, results, context)
+			m.checkNodeWithPath(valueNode, segs, results, context, visited)
 			segs = segs[:len(segs)-1] // pop
 		}
 
 	case yaml.SequenceNode:
 		for i, item := range node.Content {
 			segs = append(segs, "["+strconv.Itoa(i)+"]") // push
-			m.checkNodeWithPath(item, segs, results, context)
+			m.checkNodeWithPath(item, segs, results, context, visited)
 			segs = segs[:len(segs)-1] // pop
 		}
 	}

--- a/motor/rule_applicator_test.go
+++ b/motor/rule_applicator_test.go
@@ -2831,6 +2831,63 @@ components:
 		"resolved: true with given '$' should find 'openapi' on the root node")
 }
 
+// TestIssue829_MigrateZallyIgnoreCircularReferences verifies that the
+// migrate-zally-ignore rule runs against unresolved YAML and does not recurse
+// indefinitely when the document contains indirect circular references.
+func TestIssue829_MigrateZallyIgnoreCircularReferences(t *testing.T) {
+	spec := []byte(`openapi: 3.1.0
+info:
+  title: some title
+  description: my description
+  version: 2.5.0
+paths:
+  /endpoint:
+    get:
+      summary: summary
+      operationId: endpoint
+      responses:
+        '200':
+          description: get all
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Object'
+components:
+  schemas:
+    BaseObject:
+      type: object
+      x-zally-ignore: schema-rule
+      properties:
+        attr1:
+          $ref: '#/components/schemas/IndirectReference'
+    Object:
+      type: object
+      properties:
+        attr1:
+          $ref: '#/components/schemas/BaseObject'
+    IndirectReference:
+      $ref: '#/components/schemas/BaseObject'
+`)
+
+	rs := &rulesets.RuleSet{
+		Rules: map[string]*model.Rule{
+			rulesets.MigrateZallyIgnoreRule: rulesets.GetMigrateZallyIgnoreRule(),
+		},
+	}
+
+	results := ApplyRulesToRuleSet(&RuleSetExecution{
+		RuleSet:     rs,
+		Spec:        spec,
+		SilenceLogs: true,
+	})
+
+	assert.Len(t, results.Errors, 0)
+
+	ruleResults := filterResultsByRuleId(results.Results, rulesets.MigrateZallyIgnoreRule)
+	assert.Len(t, ruleResults, 1)
+	assert.Equal(t, "$.components.schemas.BaseObject.x-zally-ignore", ruleResults[0].Path)
+}
+
 // filterResultsByRuleId returns only results matching the given rule ID.
 func filterResultsByRuleId(results []model.RuleFunctionResult, ruleId string) []model.RuleFunctionResult {
 	var filtered []model.RuleFunctionResult

--- a/rulesets/ruleset_functions.go
+++ b/rulesets/ruleset_functions.go
@@ -1460,7 +1460,7 @@ func GetMigrateZallyIgnoreRule() *model.Rule {
 		Formats:      model.AllFormats,
 		Description:  "x-zally-ignore keys should be migrated to x-lint-ignore for compatibility with vacuum",
 		Given:        "$",
-		Resolved:     true,
+		Resolved:     false,
 		RuleCategory: model.RuleCategories[model.CategoryValidation],
 		Recommended:  true,
 		Type:         Validation,


### PR DESCRIPTION
the zally migrate ignore rule needs to not use a resolved spec.

and we need to add some tracking to the rule to make sure.