### PR TITLE
I really don’t like go-releaser anymore.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,7 @@ jobs:
           cache-dependency-path: html-report/ui/package-lock.json
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
every single time I go to push, it’s freaking broken or deprecated or needs a new config. I wish it had stayed small and focused and not turned into postman.