### PR TITLE
Allow root-relative server URLs in `oas3-api-servers`

### DIFF
--- a/functions/openapi/openapi_api_servers.go
+++ b/functions/openapi/openapi_api_servers.go
@@ -94,6 +94,11 @@ func (as APIServers) RunRule(nodes []*yaml.Node, context model.RuleFunctionConte
 			continue
 		}
 
+		// allow relative root URLs that resolve against the document location.
+		if urlNode.Value == "" || urlNode.Value == "/" {
+			continue
+		}
+
 		// check the host and the path are not empty.
 		if parsed.Host == "" && parsed.Path == "" {
 			msg := "Server URL is not valid: no hostname or path provided"

--- a/functions/openapi/openapi_api_servers_test.go
+++ b/functions/openapi/openapi_api_servers_test.go
@@ -222,3 +222,49 @@ paths:
 
 	assert.Len(t, res, 1)
 }
+
+func TestAPIServers_RunRule_Success_RelativeRootSlash(t *testing.T) {
+
+	yml := `servers:
+  - url: /
+paths:
+  /nice/cake:`
+
+	path := "$"
+
+	specInfo, _ := datamodel.ExtractSpecInfo([]byte(yml))
+
+	rule := buildOpenApiTestRuleAction(path, "api_servers", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	config := index.CreateOpenAPIIndexConfig()
+	ctx.Index = index.NewSpecIndexWithConfig(specInfo.RootNode, config)
+	ctx.SpecInfo = specInfo
+
+	def := APIServers{}
+	res := def.RunRule([]*yaml.Node{specInfo.RootNode}, ctx)
+
+	assert.Len(t, res, 0)
+}
+
+func TestAPIServers_RunRule_Success_RelativeRootEmpty(t *testing.T) {
+
+	yml := `servers:
+  - url: ""
+paths:
+  /nice/cake:`
+
+	path := "$"
+
+	specInfo, _ := datamodel.ExtractSpecInfo([]byte(yml))
+
+	rule := buildOpenApiTestRuleAction(path, "api_servers", "", nil)
+	ctx := buildOpenApiTestContext(model.CastToRuleAction(rule.Then), nil)
+	config := index.CreateOpenAPIIndexConfig()
+	ctx.Index = index.NewSpecIndexWithConfig(specInfo.RootNode, config)
+	ctx.SpecInfo = specInfo
+
+	def := APIServers{}
+	res := def.RunRule([]*yaml.Node{specInfo.RootNode}, ctx)
+
+	assert.Len(t, res, 0)
+}


### PR DESCRIPTION
`oas3-api-servers` rejected both `"/"` and `""`, leaving no lintable way to express “same origin as the OpenAPI document” despite OpenAPI allowing relative server URLs. This made common root deployment configs fail validation.

- **Rule behavior update**
  - Added an explicit allow-path for root-relative server URLs:
    - `url: "/"` (root-relative)
    - `url: ""` (document-relative base)
  - Kept existing validation for all other values, including rejection of host/path-empty non-root forms.

- **Validation semantics preserved**
  - No broad relaxation of URL checks.
  - Trailing-slash enforcement and other URL validation behavior remain unchanged for non-root server URLs.

- **Coverage added**
  - Added focused unit tests proving both accepted root-relative cases pass:
    - `TestAPIServers_RunRule_Success_RelativeRootSlash`
    - `TestAPIServers_RunRule_Success_RelativeRootEmpty`

```go
// allow relative root URLs that resolve against the document location.
if urlNode.Value == "" || urlNode.Value == "/" {
    continue
}
```

Fixes #858 