### PR TITLE
LSP support for multifile spec

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/daveshanley/vacuum/loader"
 	"log/slog"
 	"net/http"
 	"time"
@@ -116,7 +117,7 @@ func GetDashboardCommand() *cobra.Command {
 				}
 			}
 
-			reportOrSpec, err := LoadFileAsReportOrSpecWithClient(args[0], httpClient)
+			reportOrSpec, err := loader.LoadFileAsReportOrSpecWithClient(args[0], httpClient)
 			if err != nil {
 				message := fmt.Sprintf("Failed to load file: %v", err)
 				style := createResultBoxStyle(color.RGBRed, color.RGBDarkRed)

--- a/cmd/language_server.go
+++ b/cmd/language_server.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"fmt"
 	"log/slog"
+	"path/filepath"
 
 	languageserver "github.com/daveshanley/vacuum/language-server"
 	"github.com/daveshanley/vacuum/logging"
@@ -31,6 +32,16 @@ IDE and start linting your OpenAPI documents in real-time.`,
 			handler := logging.NewBufferedLogHandler(bufferedLogger)
 			logger := slog.New(handler)
 
+			var mainSpecPath string
+			if len(args) == 0 {
+				mainSpecPath = ""
+			} else {
+				var err error
+				mainSpecPath, err = filepath.Abs(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to resolve path: %w", err)
+				}
+			}
 			// extract flags
 			rulesetFlag, _ := cmd.Flags().GetString("ruleset")
 			functionsFlag, _ := cmd.Flags().GetString("functions")
@@ -99,6 +110,7 @@ IDE and start linting your OpenAPI documents in real-time.`,
 			}
 
 			lfr := utils.LintFileRequest{
+				MainSpecPath:             mainSpecPath,
 				BaseFlag:                 baseFlag,
 				Remote:                   remoteFlag,
 				SkipCheckFlag:            skipCheckFlag,

--- a/cmd/language_server.go
+++ b/cmd/language_server.go
@@ -127,7 +127,11 @@ IDE and start linting your OpenAPI documents in real-time.`,
 				HTTPClientConfig:         httpClientConfig,
 			}
 
-			return languageserver.NewServer(GetVersion(), &lfr).Run()
+			server, err := languageserver.NewServer(GetVersion(), &lfr)
+			if err != nil {
+				return err
+			}
+			return server.Run()
 		},
 	}
 	cmd.Flags().Bool("ignore-array-circle-ref", false, "Ignore circular array references")

--- a/cmd/lint_cmd.go
+++ b/cmd/lint_cmd.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/daveshanley/vacuum/loader"
 	"log/slog"
 	"net/http"
 	"os"
@@ -138,7 +139,7 @@ func runLint(cmd *cobra.Command, args []string) error {
 	}
 
 	// try to load the file as either a report or spec (supports URLs)
-	reportOrSpec, err := LoadFileAsReportOrSpecWithClient(fileName, httpClient)
+	reportOrSpec, err := loader.LoadFileAsReportOrSpecWithClient(fileName, httpClient)
 	if err != nil {
 		if !flags.SilentFlag {
 			fmt.Printf("\033[31mUnable to load file '%s': %v\033[0m\n", fileName, err)

--- a/cmd/report_loader.go
+++ b/cmd/report_loader.go
@@ -5,134 +5,16 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/daveshanley/vacuum/model"
+	"github.com/daveshanley/vacuum/loader"
 	vacuum_report "github.com/daveshanley/vacuum/vacuum-report"
+	"os"
 )
-
-// ReportLoadResult contains the results of attempting to load a file as either
-// a pre-compiled vacuum report or raw OpenAPI spec
-type ReportLoadResult struct {
-	// If the file was a pre-compiled report
-	IsReport bool
-	Report   *vacuum_report.VacuumReport
-
-	// The raw spec bytes (either from file or extracted from report)
-	SpecBytes []byte
-
-	// The filename/path for display
-	FileName string
-
-	// Pre-processed results if from a report
-	ResultSet *model.RuleResultSet
-}
 
 // LoadFileAsReportOrSpec attempts to load a file as either a pre-compiled vacuum report
 // or as a raw OpenAPI specification. It returns a ReportLoadResult with all the necessary
 // data for either case. Supports both local file paths and remote URLs (http/https).
-func LoadFileAsReportOrSpec(filePath string) (*ReportLoadResult, error) {
-	return LoadFileAsReportOrSpecWithClient(filePath, nil)
-}
-
-// LoadFileAsReportOrSpecWithClient attempts to load a file as either a pre-compiled vacuum report
-// or as a raw OpenAPI specification with optional HTTP client for TLS configuration.
-// Supports both local file paths and remote URLs (http/https).
-func LoadFileAsReportOrSpecWithClient(filePath string, httpClient *http.Client) (*ReportLoadResult, error) {
-	result := &ReportLoadResult{
-		FileName: filePath,
-	}
-
-	var bytes []byte
-	var err error
-
-	// Check if the path is a URL
-	if strings.HasPrefix(filePath, "http://") || strings.HasPrefix(filePath, "https://") {
-		bytes, err = fetchRemoteSpec(filePath, httpClient)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch remote spec '%s': %w", filePath, err)
-		}
-	} else {
-		// Get the absolute path for consistent handling of local files
-		absPath, pathErr := filepath.Abs(filePath)
-		if pathErr != nil {
-			return nil, fmt.Errorf("failed to resolve path: %w", pathErr)
-		}
-
-		bytes, err = os.ReadFile(absPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file '%s': %w", filePath, err)
-		}
-	}
-
-	// Try to parse as a vacuum report
-	vacuumReport, parseErr := vacuum_report.CheckFileForVacuumReport(bytes)
-	if parseErr != nil {
-		// File was read but isn't a report - treat as spec
-		result.SpecBytes = bytes
-		result.IsReport = false
-		return result, nil
-	}
-
-	// Check if it's actually a report
-	if vacuumReport != nil && vacuumReport.ResultSet != nil {
-		result.IsReport = true
-		result.Report = vacuumReport
-		result.ResultSet = vacuumReport.ResultSet
-
-		// Extract spec bytes from the report if available
-		if vacuumReport.SpecInfo != nil && vacuumReport.SpecInfo.SpecBytes != nil {
-			result.SpecBytes = *vacuumReport.SpecInfo.SpecBytes
-		}
-
-		// Use the original filename from the report's execution if available
-		if vacuumReport.Execution != nil && vacuumReport.Execution.SpecFileName != "" {
-			result.FileName = vacuumReport.Execution.SpecFileName
-		}
-
-		return result, nil
-	}
-
-	// Not a report, treat as regular spec file
-	result.SpecBytes = bytes
-	result.IsReport = false
-	return result, nil
-}
-
-// fetchRemoteSpec downloads a spec file from a remote URL
-func fetchRemoteSpec(url string, httpClient *http.Client) ([]byte, error) {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Add a reasonable user agent
-	req.Header.Set("User-Agent", "vacuum-linter/1.0")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, resp.Status)
-	}
-
-	bytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	return bytes, nil
+func LoadFileAsReportOrSpec(filePath string) (*loader.ReportLoadResult, error) {
+	return loader.LoadFileAsReportOrSpecWithClient(filePath, nil)
 }
 
 // LoadReportOnly attempts to load a file specifically as a vacuum report.

--- a/language-server/server.go
+++ b/language-server/server.go
@@ -17,6 +17,7 @@ package languageserver
 
 import (
 	"fmt"
+	"github.com/daveshanley/vacuum/loader"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -280,11 +281,21 @@ func (s *ServerState) Run() error {
 func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 	// Copy document data while holding read lock to avoid data race
 	doc.mu.RLock()
-	content := doc.Content
 	uri := doc.URI
-	doc.mu.RUnlock()
+	currentPath := strings.TrimPrefix(uri, "file://")
 
-	specFileName := strings.TrimPrefix(uri, "file://")
+	var specFileName string
+	var content []byte
+	if s.lintRequest.MainSpecPath != "" {
+		specFileName = s.lintRequest.MainSpecPath
+		reportLoadResult, _ := loader.LoadFileAsReportOrSpecWithClient(specFileName, nil)
+		content = reportLoadResult.SpecBytes
+	} else {
+		specFileName = currentPath
+		content = []byte(doc.Content)
+	}
+
+	doc.mu.RUnlock()
 
 	// Copy config data while holding config lock to avoid data race
 	s.configMu.RLock()
@@ -299,7 +310,7 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 	// Build the rule execution config with copied values
 	ruleExec := &motor.RuleSetExecution{
 		RuleSet:                         s.lintRequest.SelectedRS,
-		Spec:                            []byte(content),
+		Spec:                            content,
 		SpecFileName:                    specFileName,
 		Timeout:                         time.Duration(s.lintRequest.TimeoutFlag) * time.Second,
 		NodeLookupTimeout:               time.Duration(s.lintRequest.LookupTimeoutFlag) * time.Millisecond,
@@ -337,7 +348,7 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 		}
 		filteredResults := utils.FilterIgnoredResultsWithOptions(result.Results, ignoredResults, ignoreOptions)
 		result.Results = filteredResults
-		diagnostics := ConvertResultsIntoDiagnostics(result)
+		diagnostics := ConvertResultsIntoDiagnostics(result, s.lintRequest.MainSpecPath, currentPath)
 
 		notify(protocol.ServerTextDocumentPublishDiagnostics, protocol.PublishDiagnosticsParams{
 			URI:         uri,
@@ -346,12 +357,19 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 	}()
 }
 
-func ConvertResultsIntoDiagnostics(result *motor.RuleSetExecutionResult) []protocol.Diagnostic {
+func ConvertResultsIntoDiagnostics(result *motor.RuleSetExecutionResult, mainSpecPath string, currentPath string) []protocol.Diagnostic {
 	diagnostics := []protocol.Diagnostic{}
 
 	for _, vacuumResult := range result.Results {
-		diagnostics = append(diagnostics, ConvertResultIntoDiagnostic(&vacuumResult))
-
+		var source string
+		if vacuumResult.Origin == nil {
+			source = mainSpecPath
+		} else {
+			source = vacuumResult.Origin.AbsoluteLocation
+		}
+		if mainSpecPath == "" || filepath.Clean(source) == filepath.Clean(currentPath) {
+			diagnostics = append(diagnostics, ConvertResultIntoDiagnostic(&vacuumResult))
+		}
 	}
 	return diagnostics
 }

--- a/language-server/server.go
+++ b/language-server/server.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/daveshanley/vacuum/loader"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,6 +58,7 @@ type ServerState struct {
 	documentStore   *DocumentStore
 	lintRequest     *utils.LintFileRequest
 	rulesetSelector RulesetSelector
+	httpClient      *http.Client
 
 	// Configuration layers (in order of increasing priority)
 	baseConfig    *LSPConfig // From command-line flags (immutable after init)
@@ -83,7 +85,7 @@ type ServerState struct {
 	notifyMu   sync.RWMutex
 }
 
-func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState {
+func NewServer(version string, lintRequest *utils.LintFileRequest) (*ServerState, error) {
 	handler := protocol.Handler{}
 	server := glspserv.NewServer(&handler, serverName, true)
 
@@ -109,11 +111,20 @@ func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState 
 	if lintRequest.ExtensionRefs {
 		baseConfig.ExtensionRefs = boolPtr(true)
 	}
+	var httpClient *http.Client
+	var err error
+	if utils.ShouldUseCustomHTTPClient(lintRequest.HTTPClientConfig) {
+		httpClient, err = utils.CreateCustomHTTPClient(lintRequest.HTTPClientConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		}
+	}
 
 	state := &ServerState{
 		server:        server,
 		lintRequest:   lintRequest,
 		documentStore: newDocumentStore(),
+		httpClient:    httpClient,
 		logger:        logger,
 		baseConfig:    baseConfig,
 	}
@@ -249,7 +260,7 @@ func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState 
 		return nil
 	}
 
-	return state
+	return state, nil
 }
 
 // NewServerWithRulesetSelector creates a new instance of the language server with
@@ -264,10 +275,13 @@ func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState 
 // Want to enable OWASP rules for only a specific server?
 // Check the value of servers[0].url and return the rules including the OWASP ruleset
 // for your specific super secure sever url.
-func NewServerWithRulesetSelector(version string, lintRequest *utils.LintFileRequest, selector RulesetSelector) *ServerState {
-	state := NewServer(version, lintRequest)
+func NewServerWithRulesetSelector(version string, lintRequest *utils.LintFileRequest, selector RulesetSelector) (*ServerState, error) {
+	state, err := NewServer(version, lintRequest)
+	if err != nil {
+		return nil, err
+	}
 	state.rulesetSelector = selector
-	return state
+	return state, nil
 }
 
 func (s *ServerState) Run() error {
@@ -288,7 +302,7 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 	var content []byte
 	if s.lintRequest.MainSpecPath != "" {
 		specFileName = s.lintRequest.MainSpecPath
-		reportLoadResult, _ := loader.LoadFileAsReportOrSpecWithClient(specFileName, nil)
+		reportLoadResult, _ := loader.LoadFileAsReportOrSpecWithClient(specFileName, s.httpClient)
 		content = reportLoadResult.SpecBytes
 	} else {
 		specFileName = currentPath

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,0 +1,125 @@
+package loader
+
+import (
+	"fmt"
+	"github.com/daveshanley/vacuum/model"
+	vacuum_report "github.com/daveshanley/vacuum/vacuum-report"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadFileAsReportOrSpecWithClient attempts to load a file as either a pre-compiled vacuum report
+// or as a raw OpenAPI specification with optional HTTP client for TLS configuration.
+// Supports both local file paths and remote URLs (http/https).
+func LoadFileAsReportOrSpecWithClient(filePath string, httpClient *http.Client) (*ReportLoadResult, error) {
+	result := &ReportLoadResult{
+		FileName: filePath,
+	}
+
+	var bytes []byte
+	var err error
+
+	// Check if the path is a URL
+	if strings.HasPrefix(filePath, "http://") || strings.HasPrefix(filePath, "https://") {
+		bytes, err = fetchRemoteSpec(filePath, httpClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch remote spec '%s': %w", filePath, err)
+		}
+	} else {
+		// Get the absolute path for consistent handling of local files
+		absPath, pathErr := filepath.Abs(filePath)
+		if pathErr != nil {
+			return nil, fmt.Errorf("failed to resolve path: %w", pathErr)
+		}
+
+		bytes, err = os.ReadFile(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file '%s': %w", filePath, err)
+		}
+	}
+
+	// Try to parse as a vacuum report
+	vacuumReport, parseErr := vacuum_report.CheckFileForVacuumReport(bytes)
+	if parseErr != nil {
+		// File was read but isn't a report - treat as spec
+		result.SpecBytes = bytes
+		result.IsReport = false
+		return result, nil
+	}
+
+	// Check if it's actually a report
+	if vacuumReport != nil && vacuumReport.ResultSet != nil {
+		result.IsReport = true
+		result.Report = vacuumReport
+		result.ResultSet = vacuumReport.ResultSet
+
+		// Extract spec bytes from the report if available
+		if vacuumReport.SpecInfo != nil && vacuumReport.SpecInfo.SpecBytes != nil {
+			result.SpecBytes = *vacuumReport.SpecInfo.SpecBytes
+		}
+
+		// Use the original filename from the report's execution if available
+		if vacuumReport.Execution != nil && vacuumReport.Execution.SpecFileName != "" {
+			result.FileName = vacuumReport.Execution.SpecFileName
+		}
+
+		return result, nil
+	}
+
+	// Not a report, treat as regular spec file
+	result.SpecBytes = bytes
+	result.IsReport = false
+	return result, nil
+}
+
+// fetchRemoteSpec downloads a spec file from a remote URL
+func fetchRemoteSpec(url string, httpClient *http.Client) ([]byte, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add a reasonable user agent
+	req.Header.Set("User-Agent", "vacuum-linter/1.0")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return bytes, nil
+}
+
+// ReportLoadResult contains the results of attempting to load a file as either
+// a pre-compiled vacuum report or raw OpenAPI spec
+type ReportLoadResult struct {
+	// If the file was a pre-compiled report
+	IsReport bool
+	Report   *vacuum_report.VacuumReport
+
+	// The raw spec bytes (either from file or extracted from report)
+	SpecBytes []byte
+
+	// The filename/path for display
+	FileName string
+
+	// Pre-processed results if from a report
+	ResultSet *model.RuleResultSet
+}

--- a/utils/lint_file_request.go
+++ b/utils/lint_file_request.go
@@ -11,6 +11,7 @@ import (
 )
 
 type LintFileRequest struct {
+	MainSpecPath             string
 	FileName                 string
 	BaseFlag                 string
 	MultiFile                bool


### PR DESCRIPTION
Previously, LSP worked on each file separately. That is, we opened a file, and only the opened file was linted. This doesn't work with multi-file specs, because externalized parts of the spec are often invalid without context. In this pull request, I'm adding the ability to specify a primary file that will always be linted when calling language-server. Next, we determine the user's current file and send only those errors to LSP that belong to the current file.