### PR TITLE
fix: preserve explicit result path from JS rule functions #755

### DIFF
--- a/plugin/javascript/js_plugin.go
+++ b/plugin/javascript/js_plugin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,6 +73,31 @@ func (j *JSRuleFunction) createErrorResult(message string, node *yaml.Node, rule
 			Rule:      ruleContext.Rule,
 		},
 	}
+}
+
+func populateJSResultDefaults(result *model.RuleFunctionResult, node *yaml.Node, origin *index.NodeOrigin, ruleContext model.RuleFunctionContext) {
+	result.StartNode = node
+	result.EndNode = node
+	result.Origin = origin
+	result.Range = reports.Range{
+		Start: reports.RangeItem{
+			Line: node.Line,
+			Char: node.Column,
+		},
+		End: reports.RangeItem{
+			Line: node.Line,
+			Char: node.Column,
+		},
+	}
+	result.Path = jsResultPathOrDefault(result.Path, ruleContext.Given)
+	result.Rule = ruleContext.Rule
+}
+
+func jsResultPathOrDefault(path string, given interface{}) string {
+	if strings.TrimSpace(path) != "" {
+		return path
+	}
+	return fmt.Sprint(given)
 }
 
 // batchNodeInfo stores node info for batch result mapping (rolodex-aware)
@@ -280,20 +306,7 @@ func (j *JSRuleFunction) extractResults(value goja.Value, node *yaml.Node, ruleC
 
 	// populate node information for each result
 	for i := range functionResults {
-		functionResults[i].StartNode = node
-		functionResults[i].EndNode = node
-		functionResults[i].Range = reports.Range{
-			Start: reports.RangeItem{
-				Line: node.Line,
-				Char: node.Column,
-			},
-			End: reports.RangeItem{
-				Line: node.Line,
-				Char: node.Column,
-			},
-		}
-		functionResults[i].Path = fmt.Sprint(ruleContext.Given)
-		functionResults[i].Rule = ruleContext.Rule
+		populateJSResultDefaults(&functionResults[i], node, nil, ruleContext)
 	}
 
 	return functionResults, nil
@@ -471,15 +484,7 @@ func (j *JSRuleFunction) extractBatchResults(
 
 		// populate node info from matched nodeInfo (includes origin from rolodex)
 		info := nodeInfos[nodeIdx]
-		result.StartNode = info.node
-		result.EndNode = info.node
-		result.Origin = info.origin
-		result.Range = reports.Range{
-			Start: reports.RangeItem{Line: info.node.Line, Char: info.node.Column},
-			End:   reports.RangeItem{Line: info.node.Line, Char: info.node.Column},
-		}
-		result.Path = fmt.Sprint(ruleContext.Given)
-		result.Rule = ruleContext.Rule
+		populateJSResultDefaults(&result, info.node, info.origin, ruleContext)
 
 		functionResults = append(functionResults, result)
 	}

--- a/plugin/javascript/js_plugin_test.go
+++ b/plugin/javascript/js_plugin_test.go
@@ -41,6 +41,36 @@ function runRule(input) {
 	assert.Equal(t, "Value must equal \"hello\" and not: hello sally and context is: name", results[0].Message)
 }
 
+func Test_JSPlugin_ResultPath_PreservesExplicitPathAndFallsBackToGiven(t *testing.T) {
+	script := `
+function runRule(input) {
+	return [
+		{
+			message: "first issue",
+			path: "$.paths['/pets'].get"
+		},
+		{
+			message: "second issue"
+		}
+	];
+}
+`
+	f := NewJSRuleFunction("pathTest", script)
+	err := f.CheckScript()
+	assert.NoError(t, err)
+
+	var y yaml.Node
+	_ = yaml.Unmarshal([]byte("openapi: 3.1.0\npaths: {}"), &y)
+
+	results := f.RunRule([]*yaml.Node{y.Content[0]}, model.RuleFunctionContext{
+		Given: "$",
+	})
+
+	assert.Len(t, results, 2)
+	assert.Equal(t, "$.paths['/pets'].get", results[0].Path)
+	assert.Equal(t, "$", results[1].Path)
+}
+
 func Test_JSPlugin_Schema_Success(t *testing.T) {
 
 	script := `function getSchema() {
@@ -699,6 +729,43 @@ function runRule(inputs) {
 	// Verify correct node mapping
 	assert.Equal(t, 1, results[0].StartNode.Line) // First node
 	assert.Equal(t, 1, results[1].StartNode.Line) // Third node (all at line 1 in this test)
+}
+
+func Test_JSPlugin_BatchMode_ResultPath_PreservesExplicitPathAndFallsBackToGiven(t *testing.T) {
+	script := `
+function runRule(inputs) {
+	return [
+		{
+			message: "first batch issue",
+			path: "$.components.schemas.Pet",
+			input: inputs[0]
+		},
+		{
+			message: "second batch issue",
+			path: " ",
+			input: inputs[1]
+		}
+	];
+}
+`
+	f := NewJSRuleFunction("batchPathTest", script)
+	err := f.CheckScript()
+	assert.NoError(t, err)
+
+	var y1, y2 yaml.Node
+	_ = yaml.Unmarshal([]byte("first"), &y1)
+	_ = yaml.Unmarshal([]byte("second"), &y2)
+
+	results := f.RunRule([]*yaml.Node{y1.Content[0], y2.Content[0]}, model.RuleFunctionContext{
+		Given: "$",
+		Options: map[string]interface{}{
+			"batch": true,
+		},
+	})
+
+	assert.Len(t, results, 2)
+	assert.Equal(t, "$.components.schemas.Pet", results[0].Path)
+	assert.Equal(t, "$", results[1].Path)
 }
 
 func Test_JSPlugin_BatchMode_MissingInput(t *testing.T) {


### PR DESCRIPTION
JS rule results previously overwrote any path returned by the script with the rule's Given path. Now an explicitly set path is preserved and Given is only used as a fallback when the path is empty.

Extract the duplicated result-population logic from extractResults and extractBatchResults into a shared populateJSResultDefaults helper, and add tests covering both standard and batch modes.