### PR TITLE
per-document runtime config with workspace configuration support

### DIFF
--- a/language-server/config.go
+++ b/language-server/config.go
@@ -5,6 +5,7 @@ package languageserver
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
@@ -28,8 +29,7 @@ func (s *ServerState) initializeConfig() {
 	_ = viper.ReadInConfig()
 
 	// Parse file config and apply it
-	s.fileConfig = s.parseViperConfig()
-	if err := s.applyEffectiveConfig(); err != nil {
+	if err := s.setFileConfig(s.parseViperConfig(), configDirectoryFromViper()); err != nil {
 		s.logger.Warn("failed to apply initial config", "error", err)
 	}
 }
@@ -108,16 +108,25 @@ func (s *ServerState) onConfigChange(e fsnotify.Event) {
 	s.logger.Info("config file changed, reloading", "file", e.Name)
 
 	// Re-parse the config from viper
-	s.fileConfig = s.parseViperConfig()
-
-	// Apply the updated configuration
-	if err := s.applyEffectiveConfig(); err != nil {
+	if err := s.setFileConfig(s.parseViperConfig(), configDirectoryFromViper()); err != nil {
 		s.logger.Warn("failed to apply config change", "error", err)
 		return
 	}
 
 	// Re-lint all open documents if we have a notify function
+	s.clearDocumentRuntimeConfigCache()
 	if notify := s.getNotifyFunc(); notify != nil {
 		s.relintAllDocuments(notify)
 	}
+}
+
+func configDirectoryFromViper() string {
+	if used := viper.ConfigFileUsed(); used != "" {
+		if absPath, err := filepath.Abs(used); err == nil {
+			return filepath.Dir(absPath)
+		} else {
+			return filepath.Dir(used)
+		}
+	}
+	return ""
 }

--- a/language-server/lsp_config_test.go
+++ b/language-server/lsp_config_test.go
@@ -111,6 +111,31 @@ func TestParseLSPConfig_NilData(t *testing.T) {
 	assert.Nil(t, config)
 }
 
+func TestParseLSPConfig_NullDefaultsStayUnset(t *testing.T) {
+	data := map[string]interface{}{
+		"ruleset":       nil,
+		"ignoreFile":    nil,
+		"functions":     nil,
+		"base":          nil,
+		"remote":        nil,
+		"skipCheck":     nil,
+		"timeout":       nil,
+		"lookupTimeout": nil,
+		"hardMode":      nil,
+		"extensionRefs": nil,
+		"languageServer": map[string]interface{}{
+			"enabled": true,
+		},
+		"executablePath": "",
+	}
+
+	config, err := ParseLSPConfig(data)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, config)
+	assert.True(t, config.isEmpty())
+}
+
 func TestLSPConfig_IsEmpty(t *testing.T) {
 	empty := &LSPConfig{}
 	assert.True(t, empty.isEmpty())

--- a/language-server/runtime_config.go
+++ b/language-server/runtime_config.go
@@ -1,0 +1,643 @@
+// Copyright 2024-2026 Dave Shanley / Quobix / Princess Beef Heavy Industries, LLC
+// SPDX-License-Identifier: MIT
+
+package languageserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/daveshanley/vacuum/model"
+	"github.com/daveshanley/vacuum/plugin"
+	"github.com/daveshanley/vacuum/rulesets"
+	"github.com/daveshanley/vacuum/utils"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	"go.yaml.in/yaml/v4"
+)
+
+const lspConfigurationSection = "vacuum"
+
+type documentRuntimeConfig struct {
+	generation                     uint64
+	config                         *LSPConfig
+	defaultRuleSets                rulesets.RuleSets
+	selectedRS                     *rulesets.RuleSet
+	functions                      map[string]model.RuleFunction
+	ignoredResults                 model.IgnoredItems
+	httpClientConfig               utils.HTTPClientConfig
+	logger                         *slog.Logger
+	remote                         bool
+	skipCheck                      bool
+	ignoreArrayCircleRef           bool
+	ignorePolymorphCircleRef       bool
+	extensionRefs                  bool
+	timeoutSecondsValue            int
+	lookupTimeoutMillisecondsValue int
+}
+
+type lintRequestSnapshot struct {
+	defaultRuleSets          rulesets.RuleSets
+	selectedRS               *rulesets.RuleSet
+	functions                map[string]model.RuleFunction
+	ignoredResults           model.IgnoredItems
+	httpClientConfig         utils.HTTPClientConfig
+	logger                   *slog.Logger
+	remote                   bool
+	skipCheck                bool
+	ignoreArrayCircleRef     bool
+	ignorePolymorphCircleRef bool
+	extensionRefs            bool
+	timeoutFlag              int
+	lookupTimeoutFlag        int
+}
+
+func (c *documentRuntimeConfig) timeoutSeconds() int {
+	return c.timeoutSecondsValue
+}
+
+func (c *documentRuntimeConfig) lookupTimeoutMilliseconds() int {
+	return c.lookupTimeoutMillisecondsValue
+}
+
+func (s *ServerState) setClientCapabilities(capabilities protocol.ClientCapabilities) {
+	if capabilities.Workspace == nil {
+		return
+	}
+	workspace := capabilities.Workspace
+	if workspace.Configuration != nil {
+		s.workspaceConfigurationSupported = *workspace.Configuration
+	}
+	if workspace.DidChangeConfiguration != nil && workspace.DidChangeConfiguration.DynamicRegistration != nil {
+		s.didChangeConfigurationDynamicRegistrationSupported = *workspace.DidChangeConfiguration.DynamicRegistration
+	}
+}
+
+func (s *ServerState) registerConfigurationChangeNotifications(call glsp.CallFunc) {
+	if call == nil || !s.didChangeConfigurationDynamicRegistrationSupported {
+		return
+	}
+
+	var result any
+	call(string(protocol.ServerClientRegisterCapability), protocol.RegistrationParams{
+		Registrations: []protocol.Registration{
+			{
+				ID:     "vacuum-workspace-configuration",
+				Method: string(protocol.MethodWorkspaceDidChangeConfiguration),
+				RegisterOptions: map[string]any{
+					"section": lspConfigurationSection,
+				},
+			},
+		},
+	}, &result)
+}
+
+func (s *ServerState) runtimeConfigForDocument(uri protocol.DocumentUri) (*documentRuntimeConfig, error) {
+	for {
+		if cached := s.cachedDocumentRuntimeConfig(uri); cached != nil {
+			return cached, nil
+		}
+
+		config, snapshot, generation := s.baseEffectiveConfig(!s.workspaceConfigurationSupported)
+		if workspaceConfig, ok := s.pullWorkspaceConfiguration(uri); ok {
+			MergeConfig(config, workspaceConfig)
+		}
+
+		runtimeConfig, err := s.buildDocumentRuntimeConfig(config, uri, snapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		if s.cacheDocumentRuntimeConfig(uri, runtimeConfig, generation) {
+			return runtimeConfig, nil
+		}
+	}
+}
+
+func (s *ServerState) defaultRuntimeConfig(uri protocol.DocumentUri) *documentRuntimeConfig {
+	config, snapshot, _ := s.baseEffectiveConfig(!s.workspaceConfigurationSupported)
+	runtimeConfig, err := s.buildDocumentRuntimeConfig(config, uri, snapshot)
+	if err == nil {
+		return runtimeConfig
+	}
+	return s.fallbackRuntimeConfig(config, snapshot)
+}
+
+func (s *ServerState) fallbackRuntimeConfig(config *LSPConfig, snapshot lintRequestSnapshot) *documentRuntimeConfig {
+	defaultRuleSets := snapshot.defaultRuleSets
+	if defaultRuleSets == nil {
+		defaultRuleSets = rulesets.BuildDefaultRuleSetsWithLogger(s.logger)
+	}
+	selectedRS := snapshot.selectedRS
+	if config != nil && config.HardMode != nil {
+		if *config.HardMode {
+			selectedRS = generateHardModeRuleSet(defaultRuleSets)
+		} else if config.Ruleset == "" {
+			defaultRuleSets = rulesets.BuildDefaultRuleSetsWithLogger(s.logger)
+			selectedRS = defaultRuleSets.GenerateOpenAPIRecommendedRuleSet()
+		}
+	}
+	if selectedRS == nil {
+		selectedRS = defaultRuleSets.GenerateOpenAPIRecommendedRuleSet()
+	}
+	if config == nil {
+		config = &LSPConfig{
+			Remote:        boolPtr(snapshot.remote),
+			SkipCheck:     boolPtr(snapshot.skipCheck),
+			Timeout:       intPtr(nonZeroInt(snapshot.timeoutFlag, 5)),
+			LookupTimeout: intPtr(nonZeroInt(snapshot.lookupTimeoutFlag, 500)),
+		}
+	}
+	return &documentRuntimeConfig{
+		config:                         config,
+		defaultRuleSets:                defaultRuleSets,
+		selectedRS:                     selectedRS,
+		functions:                      snapshot.functions,
+		ignoredResults:                 snapshot.ignoredResults,
+		httpClientConfig:               snapshot.httpClientConfig,
+		logger:                         snapshot.logger,
+		remote:                         boolValue(config.Remote, snapshot.remote),
+		skipCheck:                      boolValue(config.SkipCheck, snapshot.skipCheck),
+		ignoreArrayCircleRef:           boolValue(config.IgnoreArrayCircleRef, snapshot.ignoreArrayCircleRef),
+		ignorePolymorphCircleRef:       boolValue(config.IgnorePolymorphCircleRef, snapshot.ignorePolymorphCircleRef),
+		extensionRefs:                  boolValue(config.ExtensionRefs, snapshot.extensionRefs),
+		timeoutSecondsValue:            intValue(config.Timeout, nonZeroInt(snapshot.timeoutFlag, 5)),
+		lookupTimeoutMillisecondsValue: intValue(config.LookupTimeout, nonZeroInt(snapshot.lookupTimeoutFlag, 500)),
+	}
+}
+
+func (s *ServerState) baseEffectiveConfig(includeRuntime bool) (*LSPConfig, lintRequestSnapshot, uint64) {
+	effective := &LSPConfig{
+		Remote:  boolPtr(true),
+		Timeout: intPtr(5),
+	}
+
+	s.configMu.RLock()
+	generation := s.configGeneration
+	snapshot := s.lintRequestSnapshotLocked()
+	MergeConfig(effective, s.baseConfig)
+	MergeConfig(effective, s.fileConfig)
+	MergeConfig(effective, s.initConfig)
+	if includeRuntime {
+		MergeConfig(effective, s.runtimeConfig)
+	}
+
+	if effective.LookupTimeout == nil || *effective.LookupTimeout == 0 {
+		effective.LookupTimeout = intPtr(nonZeroInt(snapshot.lookupTimeoutFlag, 500))
+	}
+	if effective.Timeout == nil || *effective.Timeout == 0 {
+		effective.Timeout = intPtr(nonZeroInt(snapshot.timeoutFlag, 5))
+	}
+	s.configMu.RUnlock()
+	return effective, snapshot, generation
+}
+
+func (s *ServerState) lintRequestSnapshotLocked() lintRequestSnapshot {
+	snapshot := lintRequestSnapshot{
+		logger:            s.logger,
+		remote:            true,
+		timeoutFlag:       5,
+		lookupTimeoutFlag: 500,
+	}
+	if s.lintRequest == nil {
+		return snapshot
+	}
+
+	snapshot.defaultRuleSets = s.lintRequest.DefaultRuleSets
+	snapshot.selectedRS = s.lintRequest.SelectedRS
+	snapshot.functions = s.lintRequest.Functions
+	snapshot.ignoredResults = s.lintRequest.IgnoredResults
+	snapshot.httpClientConfig = s.lintRequest.HTTPClientConfig
+	if s.lintRequest.Logger != nil {
+		snapshot.logger = s.lintRequest.Logger
+	}
+	snapshot.remote = s.lintRequest.Remote
+	snapshot.skipCheck = s.lintRequest.SkipCheckFlag
+	snapshot.ignoreArrayCircleRef = s.lintRequest.IgnoreArrayCircleRef
+	snapshot.ignorePolymorphCircleRef = s.lintRequest.IgnorePolymorphCircleRef
+	snapshot.extensionRefs = s.lintRequest.ExtensionRefs
+	snapshot.timeoutFlag = s.lintRequest.TimeoutFlag
+	snapshot.lookupTimeoutFlag = s.lintRequest.LookupTimeoutFlag
+	return snapshot
+}
+
+func boolValue(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func intValue(value *int, fallback int) int {
+	if value == nil || *value == 0 {
+		return fallback
+	}
+	return *value
+}
+
+func nonZeroInt(value int, fallback int) int {
+	if value == 0 {
+		return fallback
+	}
+	return value
+}
+
+func generateHardModeRuleSet(defaultRuleSets rulesets.RuleSets) *rulesets.RuleSet {
+	base := defaultRuleSets.GenerateOpenAPIDefaultRuleSet()
+	owaspRules := rulesets.GetAllOWASPRules()
+	selectedRS := *base
+	selectedRS.Rules = make(map[string]*model.Rule, len(base.Rules)+len(owaspRules))
+	for k, v := range base.Rules {
+		selectedRS.Rules[k] = v
+	}
+	for k, v := range owaspRules {
+		selectedRS.Rules[k] = v
+	}
+	return &selectedRS
+}
+
+func (s *ServerState) pullWorkspaceConfiguration(uri protocol.DocumentUri) (*LSPConfig, bool) {
+	if !s.workspaceConfigurationSupported {
+		return nil, false
+	}
+	call := s.getCallFunc()
+	if call == nil {
+		return nil, false
+	}
+
+	scopeURI := uri
+	section := lspConfigurationSection
+	var result []any
+	call(string(protocol.ServerWorkspaceConfiguration), protocol.ConfigurationParams{
+		Items: []protocol.ConfigurationItem{
+			{
+				ScopeURI: &scopeURI,
+				Section:  &section,
+			},
+		},
+	}, &result)
+	if len(result) == 0 || result[0] == nil {
+		return nil, true
+	}
+
+	config, err := ParseLSPConfig(result[0])
+	if err != nil {
+		s.logger.Warn("failed to parse workspace configuration", "uri", uri, "error", err)
+		return nil, true
+	}
+	return config, true
+}
+
+func (s *ServerState) buildDocumentRuntimeConfig(config *LSPConfig, uri protocol.DocumentUri, snapshot lintRequestSnapshot) (*documentRuntimeConfig, error) {
+	httpClientConfig := snapshot.httpClientConfig
+	if config.CertFile != "" {
+		httpClientConfig.CertFile = config.CertFile
+	}
+	if config.KeyFile != "" {
+		httpClientConfig.KeyFile = config.KeyFile
+	}
+	if config.CAFile != "" {
+		httpClientConfig.CAFile = config.CAFile
+	}
+	if config.Insecure != nil {
+		httpClientConfig.Insecure = *config.Insecure
+	}
+
+	defaultRuleSets := snapshot.defaultRuleSets
+	if defaultRuleSets == nil {
+		defaultRuleSets = rulesets.BuildDefaultRuleSetsWithLogger(s.logger)
+	}
+	hardMode := config.HardMode != nil && *config.HardMode
+	selectedRS := snapshot.selectedRS
+	if hardMode {
+		selectedRS = generateHardModeRuleSet(defaultRuleSets)
+	} else if config.Ruleset != "" {
+		ruleset, err := s.loadRulesetForDocument(config.Ruleset, config, defaultRuleSets, httpClientConfig, uri)
+		if err != nil {
+			return nil, err
+		}
+		selectedRS = ruleset
+	} else if config.HardMode != nil {
+		defaultRuleSets = rulesets.BuildDefaultRuleSetsWithLogger(s.logger)
+		selectedRS = defaultRuleSets.GenerateOpenAPIRecommendedRuleSet()
+	} else if selectedRS == nil {
+		selectedRS = defaultRuleSets.GenerateOpenAPIRecommendedRuleSet()
+	}
+
+	functions := snapshot.functions
+	if config.Functions != "" {
+		resolvedFunctions, err := s.resolveDocumentConfigPath(config.Functions, uri)
+		if err != nil {
+			return nil, err
+		}
+		pm, err := plugin.LoadFunctions(resolvedFunctions, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load functions from %s: %w", resolvedFunctions, err)
+		}
+		functions = pm.GetCustomFunctions()
+	}
+
+	ignoredResults := snapshot.ignoredResults
+	if config.IgnoreFile != "" {
+		resolvedIgnoreFile, err := s.resolveDocumentConfigPath(config.IgnoreFile, uri)
+		if err != nil {
+			return nil, err
+		}
+		ignoredResults, err = loadIgnoreFileForLSP(resolvedIgnoreFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &documentRuntimeConfig{
+		config:                         config,
+		defaultRuleSets:                defaultRuleSets,
+		selectedRS:                     selectedRS,
+		functions:                      functions,
+		ignoredResults:                 ignoredResults,
+		httpClientConfig:               httpClientConfig,
+		logger:                         snapshot.logger,
+		remote:                         boolValue(config.Remote, snapshot.remote),
+		skipCheck:                      boolValue(config.SkipCheck, snapshot.skipCheck),
+		ignoreArrayCircleRef:           boolValue(config.IgnoreArrayCircleRef, snapshot.ignoreArrayCircleRef),
+		ignorePolymorphCircleRef:       boolValue(config.IgnorePolymorphCircleRef, snapshot.ignorePolymorphCircleRef),
+		extensionRefs:                  boolValue(config.ExtensionRefs, snapshot.extensionRefs),
+		timeoutSecondsValue:            intValue(config.Timeout, nonZeroInt(snapshot.timeoutFlag, 5)),
+		lookupTimeoutMillisecondsValue: intValue(config.LookupTimeout, nonZeroInt(snapshot.lookupTimeoutFlag, 500)),
+	}, nil
+}
+
+func (s *ServerState) loadRulesetForDocument(rulesetLocation string, config *LSPConfig, defaultRuleSets rulesets.RuleSets, httpClientConfig utils.HTTPClientConfig, uri protocol.DocumentUri) (*rulesets.RuleSet, error) {
+	httpClient, err := utils.CreateHTTPClientIfNeeded(httpClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if isRemoteConfigLocation(rulesetLocation) {
+		if config.Remote != nil && !*config.Remote {
+			return nil, fmt.Errorf("remote ruleset specified but remote resolution is disabled")
+		}
+		downloadedRS, err := rulesets.DownloadRemoteRuleSet(context.Background(), rulesetLocation, httpClient)
+		if err != nil {
+			return nil, err
+		}
+		return defaultRuleSets.GenerateRuleSetFromSuppliedRuleSetWithHTTPClient(downloadedRS, httpClient), nil
+	}
+
+	resolvedRuleset, err := s.resolveDocumentConfigPath(rulesetLocation, uri)
+	if err != nil {
+		return nil, err
+	}
+	rsBytes, err := os.ReadFile(resolvedRuleset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ruleset %s: %w", resolvedRuleset, err)
+	}
+	userRS, err := rulesets.CreateRuleSetFromData(rsBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ruleset: %w", err)
+	}
+	return defaultRuleSets.GenerateRuleSetFromSuppliedRuleSetWithHTTPClient(userRS, httpClient), nil
+}
+
+func loadIgnoreFileForLSP(ignoreFile string) (model.IgnoredItems, error) {
+	ignoredItems := model.IgnoredItems{}
+	if ignoreFile == "" {
+		return ignoredItems, nil
+	}
+
+	raw, err := os.ReadFile(ignoreFile)
+	if err != nil {
+		return ignoredItems, fmt.Errorf("failed to read ignore file %s: %w", ignoreFile, err)
+	}
+	if err := yaml.Unmarshal(raw, &ignoredItems); err != nil {
+		return ignoredItems, fmt.Errorf("failed to parse ignore file %s: %w", ignoreFile, err)
+	}
+	return ignoredItems, nil
+}
+
+func (s *ServerState) resolveDocumentConfigPath(raw string, uri protocol.DocumentUri) (string, error) {
+	if raw == "" || isRemoteConfigLocation(raw) {
+		return raw, nil
+	}
+
+	expanded, err := expandLSPPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(expanded) {
+		return filepath.Clean(expanded), nil
+	}
+
+	dirs := uniqueDirs([]string{
+		s.workspaceFolderPathForURI(uri),
+		filepath.Dir(fileURIToPath(uri)),
+		s.configDirectory,
+		currentWorkingDirectory(),
+	})
+	for _, dir := range dirs {
+		candidate := filepath.Clean(filepath.Join(dir, expanded))
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate, nil
+		}
+	}
+	if len(dirs) > 0 {
+		return filepath.Clean(filepath.Join(dirs[0], expanded)), nil
+	}
+	return expanded, nil
+}
+
+func expandLSPPath(pathValue string) (string, error) {
+	expanded := strings.TrimSpace(pathValue)
+	if (strings.HasPrefix(expanded, `"`) && strings.HasSuffix(expanded, `"`)) ||
+		(strings.HasPrefix(expanded, `'`) && strings.HasSuffix(expanded, `'`)) {
+		expanded = expanded[1 : len(expanded)-1]
+	}
+
+	expanded = os.ExpandEnv(expanded)
+	if expanded == "~" || strings.HasPrefix(expanded, "~/") || strings.HasPrefix(expanded, "~\\") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("unable to resolve home directory: %w", err)
+		}
+		if expanded == "~" {
+			expanded = home
+		} else {
+			expanded = filepath.Join(home, expanded[2:])
+		}
+	}
+	return expanded, nil
+}
+
+func isRemoteConfigLocation(value string) bool {
+	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
+}
+
+func uniqueDirs(dirs []string) []string {
+	seen := map[string]struct{}{}
+	var unique []string
+	for _, dir := range dirs {
+		if dir == "" || dir == "." {
+			continue
+		}
+		clean := filepath.Clean(dir)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		unique = append(unique, clean)
+	}
+	return unique
+}
+
+func currentWorkingDirectory() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+func fileURIToPath(uri protocol.DocumentUri) string {
+	raw := string(uri)
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "file" {
+		return strings.TrimPrefix(raw, "file://")
+	}
+
+	pathValue := filepath.FromSlash(parsed.Path)
+	if parsed.Host != "" {
+		if os.PathSeparator == '\\' {
+			pathValue = `\\` + parsed.Host + pathValue
+		} else {
+			pathValue = "//" + parsed.Host + pathValue
+		}
+	}
+	if os.PathSeparator == '\\' && len(pathValue) >= 3 && pathValue[0] == '\\' && pathValue[2] == ':' {
+		pathValue = pathValue[1:]
+	}
+	return pathValue
+}
+
+func (s *ServerState) setWorkspaceFolders(rootURI *protocol.DocumentUri, folders []protocol.WorkspaceFolder) {
+	if len(folders) == 0 && rootURI != nil && *rootURI != "" {
+		pathValue := fileURIToPath(*rootURI)
+		folders = []protocol.WorkspaceFolder{
+			{
+				URI:  *rootURI,
+				Name: filepath.Base(pathValue),
+			},
+		}
+	}
+
+	s.workspaceMu.Lock()
+	s.workspaceFolders = append([]protocol.WorkspaceFolder(nil), folders...)
+	s.workspaceMu.Unlock()
+}
+
+func (s *ServerState) updateWorkspaceFolders(added, removed []protocol.WorkspaceFolder) {
+	s.workspaceMu.Lock()
+	defer s.workspaceMu.Unlock()
+
+	removedURIs := map[protocol.DocumentUri]struct{}{}
+	for _, folder := range removed {
+		removedURIs[folder.URI] = struct{}{}
+	}
+
+	next := make([]protocol.WorkspaceFolder, 0, len(s.workspaceFolders)+len(added))
+	for _, folder := range s.workspaceFolders {
+		if _, ok := removedURIs[folder.URI]; !ok {
+			next = append(next, folder)
+		}
+	}
+	next = append(next, added...)
+	s.workspaceFolders = next
+}
+
+func (s *ServerState) workspaceFolderPathForURI(uri protocol.DocumentUri) string {
+	documentPath := fileURIToPath(uri)
+	if documentPath == "" {
+		return ""
+	}
+
+	s.workspaceMu.RLock()
+	folders := append([]protocol.WorkspaceFolder(nil), s.workspaceFolders...)
+	s.workspaceMu.RUnlock()
+
+	var best string
+	for _, folder := range folders {
+		folderPath := fileURIToPath(folder.URI)
+		if folderPath == "" {
+			continue
+		}
+		rel, err := filepath.Rel(folderPath, documentPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			continue
+		}
+		if len(folderPath) > len(best) {
+			best = folderPath
+		}
+	}
+	return best
+}
+
+func (s *ServerState) clearDocumentRuntimeConfig(uri protocol.DocumentUri) {
+	s.documentRuntimeConfigMu.Lock()
+	if s.documentRuntimeConfigs != nil {
+		delete(s.documentRuntimeConfigs, uri)
+	}
+	s.documentRuntimeConfigMu.Unlock()
+}
+
+func (s *ServerState) cachedDocumentRuntimeConfig(uri protocol.DocumentUri) *documentRuntimeConfig {
+	s.configMu.RLock()
+	generation := s.configGeneration
+	s.documentRuntimeConfigMu.RLock()
+	cached := s.documentRuntimeConfigs[uri]
+	if cached != nil && cached.generation != generation {
+		cached = nil
+	}
+	s.documentRuntimeConfigMu.RUnlock()
+	s.configMu.RUnlock()
+	return cached
+}
+
+func (s *ServerState) cacheDocumentRuntimeConfig(uri protocol.DocumentUri, runtimeConfig *documentRuntimeConfig, generation uint64) bool {
+	s.configMu.RLock()
+	if s.configGeneration != generation {
+		s.configMu.RUnlock()
+		return false
+	}
+
+	runtimeConfig.generation = generation
+	s.documentRuntimeConfigMu.Lock()
+	if s.documentRuntimeConfigs == nil {
+		s.documentRuntimeConfigs = map[protocol.DocumentUri]*documentRuntimeConfig{}
+	}
+	s.documentRuntimeConfigs[uri] = runtimeConfig
+	s.documentRuntimeConfigMu.Unlock()
+	s.configMu.RUnlock()
+	return true
+}
+
+func (s *ServerState) clearDocumentRuntimeConfigCache() {
+	s.documentRuntimeConfigMu.Lock()
+	s.documentRuntimeConfigs = map[protocol.DocumentUri]*documentRuntimeConfig{}
+	s.documentRuntimeConfigMu.Unlock()
+}
+
+func (s *ServerState) setCallFunc(call glsp.CallFunc) {
+	s.callMu.Lock()
+	s.callFunc = call
+	s.callMu.Unlock()
+}
+
+func (s *ServerState) getCallFunc() glsp.CallFunc {
+	s.callMu.RLock()
+	defer s.callMu.RUnlock()
+	return s.callFunc
+}

--- a/language-server/runtime_config_test.go
+++ b/language-server/runtime_config_test.go
@@ -1,0 +1,260 @@
+// Copyright 2024-2026 Dave Shanley / Quobix / Princess Beef Heavy Industries, LLC
+// SPDX-License-Identifier: MIT
+
+package languageserver
+
+import (
+	"io"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/daveshanley/vacuum/rulesets"
+	"github.com/daveshanley/vacuum/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestRuntimeConfigForDocument_PullsWorkspaceConfiguration(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "ruleset.yaml"), []byte("extends: [[vacuum:oas, off]]"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "ignore.yaml"), []byte("oas3-schema:\n  - $.info.title\n"), 0o600))
+
+	defaultRuleSets := rulesets.BuildDefaultRuleSets()
+	state := &ServerState{
+		lintRequest: &utils.LintFileRequest{
+			DefaultRuleSets:      defaultRuleSets,
+			SelectedRS:           defaultRuleSets.GenerateOpenAPIRecommendedRuleSet(),
+			Remote:               true,
+			TimeoutFlag:          5,
+			LookupTimeoutFlag:    500,
+			HTTPClientConfig:     utils.HTTPClientConfig{},
+			Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+			SkipCheckFlag:        false,
+			ExtensionRefs:        false,
+			IgnoreArrayCircleRef: false,
+		},
+		logger:                          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		baseConfig:                      &LSPConfig{Remote: boolPtr(true), Timeout: intPtr(5), LookupTimeout: intPtr(500)},
+		workspaceConfigurationSupported: true,
+		documentRuntimeConfigs:          map[protocol.DocumentUri]*documentRuntimeConfig{},
+	}
+	rootURI := fileURI(tempDir)
+	specURI := fileURI(filepath.Join(tempDir, "openapi.yaml"))
+	state.setWorkspaceFolders(nil, []protocol.WorkspaceFolder{{URI: rootURI, Name: "test-workspace"}})
+	state.setCallFunc(glsp.CallFunc(func(method string, params any, result any) {
+		assert.Equal(t, string(protocol.ServerWorkspaceConfiguration), method)
+		configResult, ok := result.(*[]any)
+		require.True(t, ok)
+		*configResult = []any{
+			map[string]any{
+				"ruleset":       "ruleset.yaml",
+				"ignoreFile":    "ignore.yaml",
+				"remote":        false,
+				"skipCheck":     true,
+				"timeout":       2,
+				"lookupTimeout": 25,
+				"extensionRefs": true,
+			},
+		}
+	}))
+
+	runtimeConfig, err := state.runtimeConfigForDocument(specURI)
+
+	require.NoError(t, err)
+	require.NotNil(t, runtimeConfig.selectedRS)
+	assert.Len(t, runtimeConfig.ignoredResults, 1)
+	assert.False(t, *runtimeConfig.config.Remote)
+	assert.True(t, *runtimeConfig.config.SkipCheck)
+	assert.Equal(t, 2, runtimeConfig.timeoutSeconds())
+	assert.Equal(t, 25, runtimeConfig.lookupTimeoutMilliseconds())
+	assert.True(t, *runtimeConfig.config.ExtensionRefs)
+}
+
+func TestRuntimeConfigForDocument_NullWorkspaceDefaultsDoNotOverrideFileConfig(t *testing.T) {
+	state := newRuntimeConfigTestState()
+	require.NoError(t, state.setFileConfig(&LSPConfig{
+		Remote:        boolPtr(false),
+		SkipCheck:     boolPtr(true),
+		HardMode:      boolPtr(true),
+		LookupTimeout: intPtr(42),
+	}, ""))
+	state.workspaceConfigurationSupported = true
+	state.setCallFunc(glsp.CallFunc(func(method string, params any, result any) {
+		configResult, ok := result.(*[]any)
+		require.True(t, ok)
+		*configResult = []any{
+			map[string]any{
+				"ruleset":       nil,
+				"ignoreFile":    nil,
+				"functions":     nil,
+				"base":          nil,
+				"remote":        nil,
+				"skipCheck":     nil,
+				"timeout":       nil,
+				"lookupTimeout": nil,
+				"hardMode":      nil,
+				"extensionRefs": nil,
+			},
+		}
+	}))
+
+	runtimeConfig, err := state.runtimeConfigForDocument(fileURI(filepath.Join(t.TempDir(), "openapi.yaml")))
+
+	require.NoError(t, err)
+	assert.False(t, runtimeConfig.remote)
+	assert.True(t, runtimeConfig.skipCheck)
+	assert.True(t, *runtimeConfig.config.HardMode)
+	assert.Equal(t, 42, runtimeConfig.lookupTimeoutMilliseconds())
+}
+
+func TestRuntimeConfigForDocument_UserWorkspaceValuesOverrideFileConfig(t *testing.T) {
+	state := newRuntimeConfigTestState()
+	require.NoError(t, state.setFileConfig(&LSPConfig{
+		Remote:        boolPtr(false),
+		SkipCheck:     boolPtr(true),
+		LookupTimeout: intPtr(42),
+	}, ""))
+	state.workspaceConfigurationSupported = true
+	state.setCallFunc(glsp.CallFunc(func(method string, params any, result any) {
+		configResult, ok := result.(*[]any)
+		require.True(t, ok)
+		*configResult = []any{
+			map[string]any{
+				"remote":        true,
+				"skipCheck":     false,
+				"lookupTimeout": 25,
+			},
+		}
+	}))
+
+	runtimeConfig, err := state.runtimeConfigForDocument(fileURI(filepath.Join(t.TempDir(), "openapi.yaml")))
+
+	require.NoError(t, err)
+	assert.True(t, runtimeConfig.remote)
+	assert.False(t, runtimeConfig.skipCheck)
+	assert.Equal(t, 25, runtimeConfig.lookupTimeoutMilliseconds())
+}
+
+func TestRuntimeConfigForDocument_WorkspaceHardModeFalseRebuildsRecommendedRuleset(t *testing.T) {
+	state := newRuntimeConfigTestState()
+	require.NoError(t, state.setFileConfig(&LSPConfig{HardMode: boolPtr(true)}, ""))
+	state.workspaceConfigurationSupported = true
+	state.setCallFunc(glsp.CallFunc(func(method string, params any, result any) {
+		configResult, ok := result.(*[]any)
+		require.True(t, ok)
+		*configResult = []any{
+			map[string]any{
+				"hardMode": false,
+			},
+		}
+	}))
+
+	runtimeConfig, err := state.runtimeConfigForDocument(fileURI(filepath.Join(t.TempDir(), "openapi.yaml")))
+
+	require.NoError(t, err)
+	require.NotNil(t, runtimeConfig.selectedRS)
+	require.NotNil(t, runtimeConfig.config.HardMode)
+	assert.False(t, *runtimeConfig.config.HardMode)
+	assert.NotContains(t, runtimeConfig.selectedRS.Rules, rulesets.OwaspNoNumericIDs)
+}
+
+func TestRuntimeConfigForDocument_RebuildsWhenConfigGenerationChangesDuringBuild(t *testing.T) {
+	state := newRuntimeConfigTestState()
+	state.workspaceConfigurationSupported = true
+	specURI := fileURI(filepath.Join(t.TempDir(), "openapi.yaml"))
+	calls := 0
+	state.setCallFunc(glsp.CallFunc(func(method string, params any, result any) {
+		calls++
+		configResult, ok := result.(*[]any)
+		require.True(t, ok)
+		if calls == 1 {
+			*configResult = []any{
+				map[string]any{
+					"remote": false,
+				},
+			}
+			state.bumpConfigGeneration()
+			return
+		}
+		*configResult = []any{
+			map[string]any{
+				"remote": true,
+			},
+		}
+	}))
+
+	runtimeConfig, err := state.runtimeConfigForDocument(specURI)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+	assert.True(t, runtimeConfig.remote)
+	require.NotNil(t, state.cachedDocumentRuntimeConfig(specURI))
+	assert.True(t, state.cachedDocumentRuntimeConfig(specURI).remote)
+}
+
+func TestRuntimeConfigForDocument_PreservesCLIProvidedLookupTimeout(t *testing.T) {
+	state := newRuntimeConfigTestState()
+	state.baseConfig = nil
+	state.lintRequest.LookupTimeoutFlag = 123
+
+	runtimeConfig, err := state.runtimeConfigForDocument(fileURI(filepath.Join(t.TempDir(), "openapi.yaml")))
+
+	require.NoError(t, err)
+	assert.Equal(t, 123, runtimeConfig.lookupTimeoutMilliseconds())
+}
+
+func TestApplyWorkspaceFolderCapabilities(t *testing.T) {
+	capabilities := protocol.ServerCapabilities{}
+
+	applyWorkspaceFolderCapabilities(&capabilities)
+
+	require.NotNil(t, capabilities.Workspace)
+	require.NotNil(t, capabilities.Workspace.WorkspaceFolders)
+	require.NotNil(t, capabilities.Workspace.WorkspaceFolders.Supported)
+	assert.True(t, *capabilities.Workspace.WorkspaceFolders.Supported)
+	require.NotNil(t, capabilities.Workspace.WorkspaceFolders.ChangeNotifications)
+	assert.Equal(t, true, capabilities.Workspace.WorkspaceFolders.ChangeNotifications.Value)
+}
+
+func TestResolveDocumentConfigPath_UsesWorkspaceFolderForRelativePaths(t *testing.T) {
+	tempDir := t.TempDir()
+	nestedDir := filepath.Join(tempDir, "apis")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "ruleset.yaml"), []byte("extends: [[vacuum:oas, off]]"), 0o600))
+
+	state := &ServerState{}
+	state.setWorkspaceFolders(nil, []protocol.WorkspaceFolder{{URI: fileURI(tempDir), Name: "test-workspace"}})
+
+	resolved, err := state.resolveDocumentConfigPath("ruleset.yaml", fileURI(filepath.Join(nestedDir, "openapi.yaml")))
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempDir, "ruleset.yaml"), resolved)
+}
+
+func newRuntimeConfigTestState() *ServerState {
+	defaultRuleSets := rulesets.BuildDefaultRuleSets()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return &ServerState{
+		lintRequest: &utils.LintFileRequest{
+			DefaultRuleSets:   defaultRuleSets,
+			SelectedRS:        defaultRuleSets.GenerateOpenAPIRecommendedRuleSet(),
+			Remote:            true,
+			TimeoutFlag:       5,
+			LookupTimeoutFlag: 500,
+			HTTPClientConfig:  utils.HTTPClientConfig{},
+			Logger:            logger,
+		},
+		logger:                 logger,
+		baseConfig:             &LSPConfig{Remote: boolPtr(true), Timeout: intPtr(5), LookupTimeout: intPtr(500)},
+		documentRuntimeConfigs: map[protocol.DocumentUri]*documentRuntimeConfig{},
+	}
+}
+
+func fileURI(pathValue string) protocol.DocumentUri {
+	return protocol.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(pathValue)}).String())
+}

--- a/language-server/server.go
+++ b/language-server/server.go
@@ -68,19 +68,31 @@ type ServerState struct {
 	effectiveConfig *LSPConfig
 
 	// Synchronization for config updates
-	configMu sync.RWMutex
+	configMu         sync.RWMutex
+	configGeneration uint64
 
 	// Logger for config-related messages
 	logger *slog.Logger
 
 	// Cached resource paths to detect changes and avoid reloading
-	loadedRulesetPath   string
-	loadedFunctionsPath string
-	loadedHardMode      bool
+	loadedRulesetPath    string
+	loadedFunctionsPath  string
+	loadedIgnoreFilePath string
+	loadedHardMode       bool
+
+	workspaceConfigurationSupported                    bool
+	didChangeConfigurationDynamicRegistrationSupported bool
+	workspaceFolders                                   []protocol.WorkspaceFolder
+	workspaceMu                                        sync.RWMutex
+	configDirectory                                    string
+	documentRuntimeConfigs                             map[protocol.DocumentUri]*documentRuntimeConfig
+	documentRuntimeConfigMu                            sync.RWMutex
 
 	// Notify function for triggering re-lints (used by file watcher)
 	notifyFunc glsp.NotifyFunc
 	notifyMu   sync.RWMutex
+	callFunc   glsp.CallFunc
+	callMu     sync.RWMutex
 }
 
 func NewServer(version string, lintRequest *utils.LintFileRequest) *ServerState {
@@ -99,10 +111,11 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 
 	// Create base config from initial lintRequest values (command-line flags)
 	baseConfig := &LSPConfig{
-		Base:      lintRequest.BaseFlag,
-		Remote:    boolPtr(lintRequest.Remote),
-		SkipCheck: boolPtr(lintRequest.SkipCheckFlag),
-		Timeout:   intPtr(lintRequest.TimeoutFlag),
+		Base:          lintRequest.BaseFlag,
+		Remote:        boolPtr(lintRequest.Remote),
+		SkipCheck:     boolPtr(lintRequest.SkipCheckFlag),
+		Timeout:       intPtr(lintRequest.TimeoutFlag),
+		LookupTimeout: intPtr(lintRequest.LookupTimeoutFlag),
 	}
 	if lintRequest.IgnoreArrayCircleRef {
 		baseConfig.IgnoreArrayCircleRef = boolPtr(true)
@@ -115,17 +128,20 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 	}
 
 	state := &ServerState{
-		server:           server,
-		lintRequest:      lintRequest,
-		executionOptions: executionOptions,
-		documentStore:    newDocumentStore(),
-		logger:           logger,
-		baseConfig:       baseConfig,
+		server:                 server,
+		lintRequest:            lintRequest,
+		executionOptions:       executionOptions,
+		documentStore:          newDocumentStore(),
+		logger:                 logger,
+		baseConfig:             baseConfig,
+		documentRuntimeConfigs: map[protocol.DocumentUri]*documentRuntimeConfig{},
 	}
 	handler.Initialize = func(context *glsp.Context, params *protocol.InitializeParams) (any, error) {
 		if params.Trace != nil {
 			protocol.SetTraceValue(*params.Trace)
 		}
+		state.setClientCapabilities(params.Capabilities)
+		state.setWorkspaceFolders(params.RootURI, params.WorkspaceFolders)
 
 		// Extract and apply InitializationOptions if provided
 		if params.InitializationOptions != nil {
@@ -133,8 +149,7 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 			if err != nil {
 				state.logger.Warn("failed to parse InitializationOptions", "error", err)
 			} else if initConfig != nil {
-				state.initConfig = initConfig
-				if err := state.applyEffectiveConfig(); err != nil {
+				if err := state.setInitConfig(initConfig); err != nil {
 					state.logger.Warn("failed to apply InitializationOptions", "error", err)
 				}
 			}
@@ -149,6 +164,7 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 		serverCapabilities.ExecuteCommandProvider = &protocol.ExecuteCommandOptions{
 			Commands: []string{"vacuum.openUrl"},
 		}
+		applyWorkspaceFolderCapabilities(&serverCapabilities)
 
 		return protocol.InitializeResult{
 			Capabilities: serverCapabilities,
@@ -158,6 +174,11 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 			},
 		}, nil
 	}
+	handler.Initialized = func(context *glsp.Context, params *protocol.InitializedParams) error {
+		state.setCallFunc(context.Call)
+		state.registerConfigurationChangeNotifications(context.Call)
+		return nil
+	}
 	handler.SetTrace = func(context *glsp.Context, params *protocol.SetTraceParams) error {
 		protocol.SetTraceValue(params.Value)
 		return nil
@@ -165,12 +186,14 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 	handler.TextDocumentDidOpen = func(context *glsp.Context, params *protocol.DidOpenTextDocumentParams) error {
 		// Store notify function for file watcher re-linting
 		state.setNotifyFunc(context.Notify)
+		state.setCallFunc(context.Call)
 
 		doc := state.documentStore.Add(params.TextDocument.URI, params.TextDocument.Text)
 		state.runDiagnostic(doc, context.Notify)
 		return nil
 	}
 	handler.TextDocumentDidChange = func(context *glsp.Context, params *protocol.DidChangeTextDocumentParams) error {
+		state.setCallFunc(context.Call)
 		doc, ok := state.documentStore.Get(params.TextDocument.URI)
 		if !ok {
 			return nil
@@ -195,6 +218,7 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 
 	handler.TextDocumentDidClose = func(context *glsp.Context, params *protocol.DidCloseTextDocumentParams) error {
 		state.documentStore.Remove(params.TextDocument.URI)
+		state.clearDocumentRuntimeConfig(params.TextDocument.URI)
 		return nil
 	}
 
@@ -233,24 +257,33 @@ func NewServerWithExecutionOptions(version string, lintRequest *utils.LintFileRe
 	}
 
 	handler.WorkspaceDidChangeConfiguration = func(context *glsp.Context, params *protocol.DidChangeConfigurationParams) error {
-		config, err := ParseLSPConfig(params.Settings)
-		if err != nil {
-			state.logger.Warn("failed to parse configuration settings", "error", err)
-			return nil // Don't fail - log and continue with existing config
-		}
-
-		if config != nil {
-			state.runtimeConfig = config
-
-			if err := state.applyEffectiveConfig(); err != nil {
-				state.logger.Warn("failed to apply configuration", "error", err)
-				return nil
+		state.setCallFunc(context.Call)
+		if !state.workspaceConfigurationSupported {
+			config, err := ParseLSPConfig(params.Settings)
+			if err != nil {
+				state.logger.Warn("failed to parse configuration settings", "error", err)
+				return nil // Don't fail - log and continue with existing config
 			}
 
-			// Trigger re-linting of all open documents
-			state.relintAllDocuments(context.Notify)
+			if config != nil {
+				if err := state.setRuntimeConfig(config); err != nil {
+					state.logger.Warn("failed to apply configuration", "error", err)
+					return nil
+				}
+			}
+		} else {
+			state.bumpConfigGeneration()
 		}
 
+		// Trigger re-linting of all open documents
+		state.clearDocumentRuntimeConfigCache()
+		state.relintAllDocuments(context.Notify)
+		return nil
+	}
+	handler.WorkspaceDidChangeWorkspaceFolders = func(context *glsp.Context, params *protocol.DidChangeWorkspaceFoldersParams) error {
+		state.updateWorkspaceFolders(params.Event.Added, params.Event.Removed)
+		state.clearDocumentRuntimeConfigCache()
+		state.relintAllDocuments(context.Notify)
 		return nil
 	}
 
@@ -292,35 +325,38 @@ func (s *ServerState) runDiagnostic(doc *Document, notify glsp.NotifyFunc) {
 
 	specFileName := strings.TrimPrefix(uri, "file://")
 
-	// Copy config data while holding config lock to avoid data race
-	s.configMu.RLock()
-	baseForDoc := s.lintRequest.BaseFlag
+	runtimeConfig, err := s.runtimeConfigForDocument(uri)
+	if err != nil {
+		s.logger.Warn("failed to build document configuration", "uri", uri, "error", err)
+		runtimeConfig = s.defaultRuntimeConfig(uri)
+	}
+
+	baseForDoc := runtimeConfig.config.Base
 	if baseForDoc == "" {
 		baseForDoc = filepath.Dir(specFileName)
 	}
 
-	deepGraph := len(s.lintRequest.IgnoredResults) > 0
-	ignoredResults := s.lintRequest.IgnoredResults
+	deepGraph := len(runtimeConfig.ignoredResults) > 0
+	ignoredResults := runtimeConfig.ignoredResults
 
 	// Build the rule execution config with copied values
 	ruleExec := &motor.RuleSetExecution{
-		RuleSet:                         s.lintRequest.SelectedRS,
+		RuleSet:                         runtimeConfig.selectedRS,
 		Spec:                            []byte(content),
 		SpecFileName:                    specFileName,
-		Timeout:                         time.Duration(s.lintRequest.TimeoutFlag) * time.Second,
-		NodeLookupTimeout:               time.Duration(s.lintRequest.LookupTimeoutFlag) * time.Millisecond,
-		CustomFunctions:                 s.lintRequest.Functions,
-		IgnoreCircularArrayRef:          s.lintRequest.IgnoreArrayCircleRef,
-		IgnoreCircularPolymorphicRef:    s.lintRequest.IgnorePolymorphCircleRef,
-		AllowLookup:                     s.lintRequest.Remote,
+		Timeout:                         time.Duration(runtimeConfig.timeoutSeconds()) * time.Second,
+		NodeLookupTimeout:               time.Duration(runtimeConfig.lookupTimeoutMilliseconds()) * time.Millisecond,
+		CustomFunctions:                 runtimeConfig.functions,
+		IgnoreCircularArrayRef:          runtimeConfig.ignoreArrayCircleRef,
+		IgnoreCircularPolymorphicRef:    runtimeConfig.ignorePolymorphCircleRef,
+		AllowLookup:                     runtimeConfig.remote,
 		Base:                            baseForDoc,
-		SkipDocumentCheck:               s.lintRequest.SkipCheckFlag,
-		Logger:                          s.lintRequest.Logger,
+		SkipDocumentCheck:               runtimeConfig.skipCheck,
+		Logger:                          runtimeConfig.logger,
 		BuildDeepGraph:                  deepGraph,
-		ExtractReferencesFromExtensions: s.lintRequest.ExtensionRefs,
-		HTTPClientConfig:                s.lintRequest.HTTPClientConfig,
+		ExtractReferencesFromExtensions: runtimeConfig.extensionRefs,
+		HTTPClientConfig:                runtimeConfig.httpClientConfig,
 	}
-	s.configMu.RUnlock()
 
 	// Apply ruleset selector if configured (uses copied content)
 	if s.rulesetSelector != nil {
@@ -412,6 +448,16 @@ func ConvertResultIntoDiagnostic(vacuumResult *model.RuleFunctionResult) protoco
 	}
 }
 
+func applyWorkspaceFolderCapabilities(capabilities *protocol.ServerCapabilities) {
+	if capabilities.Workspace == nil {
+		capabilities.Workspace = &protocol.ServerCapabilitiesWorkspace{}
+	}
+	capabilities.Workspace.WorkspaceFolders = &protocol.WorkspaceFoldersServerCapabilities{
+		Supported:           boolPtr(true),
+		ChangeNotifications: &protocol.BoolOrString{Value: true},
+	}
+}
+
 func GetDiagnosticSeverityFromRule(rule *model.Rule) protocol.DiagnosticSeverity {
 	switch rule.Severity {
 	case model.SeverityError:
@@ -429,7 +475,51 @@ func GetDiagnosticSeverityFromRule(rule *model.Rule) protocol.DiagnosticSeverity
 func (s *ServerState) applyEffectiveConfig() error {
 	s.configMu.Lock()
 	defer s.configMu.Unlock()
+	s.configGeneration++
 
+	return s.applyEffectiveConfigLocked()
+}
+
+func (s *ServerState) setInitConfig(config *LSPConfig) error {
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+
+	s.initConfig = config
+	s.configGeneration++
+	return s.applyEffectiveConfigLocked()
+}
+
+func (s *ServerState) setRuntimeConfig(config *LSPConfig) error {
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+
+	s.runtimeConfig = config
+	s.configGeneration++
+	return s.applyEffectiveConfigLocked()
+}
+
+func (s *ServerState) setFileConfig(config *LSPConfig, configDirectory string) error {
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+
+	s.fileConfig = config
+	if configDirectory != "" {
+		s.configDirectory = configDirectory
+	}
+	s.configGeneration++
+	return s.applyEffectiveConfigLocked()
+}
+
+func (s *ServerState) bumpConfigGeneration() {
+	s.configMu.Lock()
+	s.configGeneration++
+	s.configMu.Unlock()
+}
+
+// applyEffectiveConfigLocked computes the effective configuration from all
+// layers and updates the lintRequest accordingly. Must be called with configMu
+// held.
+func (s *ServerState) applyEffectiveConfigLocked() error {
 	// Start with defaults
 	effective := &LSPConfig{
 		Remote:  boolPtr(true), // Default: remote lookups enabled
@@ -496,6 +586,9 @@ func (s *ServerState) updateLintRequestFromEffectiveConfig() error {
 	if err := s.loadFunctionsIfChanged(cfg); err != nil {
 		s.logger.Warn("failed to load functions", "error", err)
 	}
+	if err := s.loadIgnoreFileIfChanged(cfg); err != nil {
+		s.logger.Warn("failed to load ignore file", "error", err)
+	}
 
 	return nil
 }
@@ -515,21 +608,13 @@ func (s *ServerState) loadRulesetIfChanged(cfg *LSPConfig) error {
 	var selectedRS *rulesets.RuleSet
 
 	if hardMode {
-		selectedRS = defaultRuleSets.GenerateOpenAPIDefaultRuleSet()
-		owaspRules := rulesets.GetAllOWASPRules()
-		for k, v := range owaspRules {
-			selectedRS.Rules[k] = v
-		}
+		selectedRS = generateHardModeRuleSet(defaultRuleSets)
 	} else if effectiveRuleset != "" {
-		rsBytes, err := os.ReadFile(effectiveRuleset)
+		ruleset, err := s.loadRulesetForDocument(effectiveRuleset, cfg, defaultRuleSets, s.lintRequest.HTTPClientConfig, "")
 		if err != nil {
-			return fmt.Errorf("failed to read ruleset %s: %w", effectiveRuleset, err)
+			return err
 		}
-		userRS, err := rulesets.CreateRuleSetFromData(rsBytes)
-		if err != nil {
-			return fmt.Errorf("failed to parse ruleset: %w", err)
-		}
-		selectedRS = defaultRuleSets.GenerateRuleSetFromSuppliedRuleSet(userRS)
+		selectedRS = ruleset
 	} else {
 		selectedRS = defaultRuleSets.GenerateOpenAPIRecommendedRuleSet()
 	}
@@ -551,9 +636,13 @@ func (s *ServerState) loadFunctionsIfChanged(cfg *LSPConfig) error {
 	}
 
 	if effectiveFunctions != "" {
-		pm, err := plugin.LoadFunctions(effectiveFunctions, true)
+		resolvedFunctions, err := s.resolveDocumentConfigPath(effectiveFunctions, "")
 		if err != nil {
-			return fmt.Errorf("failed to load functions from %s: %w", effectiveFunctions, err)
+			return err
+		}
+		pm, err := plugin.LoadFunctions(resolvedFunctions, true)
+		if err != nil {
+			return fmt.Errorf("failed to load functions from %s: %w", resolvedFunctions, err)
 		}
 		s.lintRequest.Functions = pm.GetCustomFunctions()
 	} else {
@@ -561,6 +650,31 @@ func (s *ServerState) loadFunctionsIfChanged(cfg *LSPConfig) error {
 	}
 
 	s.loadedFunctionsPath = effectiveFunctions
+	return nil
+}
+
+func (s *ServerState) loadIgnoreFileIfChanged(cfg *LSPConfig) error {
+	effectiveIgnoreFile := cfg.IgnoreFile
+
+	if effectiveIgnoreFile == s.loadedIgnoreFilePath {
+		return nil
+	}
+
+	if effectiveIgnoreFile != "" {
+		resolvedIgnoreFile, err := s.resolveDocumentConfigPath(effectiveIgnoreFile, "")
+		if err != nil {
+			return err
+		}
+		ignoredResults, err := loadIgnoreFileForLSP(resolvedIgnoreFile)
+		if err != nil {
+			return err
+		}
+		s.lintRequest.IgnoredResults = ignoredResults
+	} else {
+		s.lintRequest.IgnoredResults = model.IgnoredItems{}
+	}
+
+	s.loadedIgnoreFilePath = effectiveIgnoreFile
 	return nil
 }
 


### PR DESCRIPTION
Resolve linting configuration per document by pulling client workspace configuration (workspace/configuration) and merging it over base, file, and init config layers, with results cached per document and invalidated via a config generation counter.

Address #533