### PR TITLE
fix: ensure x-lint-ignore directives respect parent ignores

### DIFF
--- a/motor/inline_ignore.go
+++ b/motor/inline_ignore.go
@@ -23,6 +23,9 @@ type inlineIgnoreIndex struct {
 	// When false, checkInlineIgnoreByPathIndexed can skip JSONPath queries
 	// and only check root-level ignores.
 	hasNonRootIgnores bool
+
+	// parents maps each node to its parent. Only built when non-root ignores exist.
+	parents map[*yaml.Node]*yaml.Node
 }
 
 // buildInlineIgnoreIndex walks the YAML tree once, building a map of
@@ -54,7 +57,24 @@ func buildInlineIgnoreIndex(node *yaml.Node) *inlineIgnoreIndex {
 	// Extract root ignores for fast access
 	idx.rootIgnores = idx.nodeIgnores[rootNode]
 
+	// Build a parent map so parent ignores can be honored during path lookups.
+	if idx.hasNonRootIgnores {
+		idx.parents = make(map[*yaml.Node]*yaml.Node)
+		buildParentMap(node, idx.parents)
+	}
+
 	return idx
+}
+
+// buildParentMap records each node's parent for parent-ignore lookups.
+func buildParentMap(node *yaml.Node, parents map[*yaml.Node]*yaml.Node) {
+	if node == nil {
+		return
+	}
+	for _, c := range node.Content {
+		parents[c] = node
+		buildParentMap(c, parents)
+	}
 }
 
 // scanAndIndex recursively walks the YAML tree, recording nodes that
@@ -133,8 +153,10 @@ func checkInlineIgnoreByPathIndexed(idx *inlineIgnoreIndex, specNode *yaml.Node,
 	// Non-root ignores exist — must do JSONPath lookup for this path
 	nodes, err := utils.FindNodesWithoutDeserializingWithTimeout(specNode, path, time.Millisecond*500)
 	if err == nil && len(nodes) > 0 {
-		if rules, ok := idx.nodeIgnores[nodes[0]]; ok {
-			return rules[ruleId]
+		// check the node and its parent
+		node := nodes[0]
+		if idx.nodeIgnores[node][ruleId] || idx.nodeIgnores[idx.parents[node]][ruleId] {
+			return true
 		}
 	}
 

--- a/motor/inline_ignore_test.go
+++ b/motor/inline_ignore_test.go
@@ -1,8 +1,11 @@
 package motor
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/daveshanley/vacuum/model"
+	"github.com/daveshanley/vacuum/rulesets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
@@ -152,6 +155,32 @@ info:
 func TestCheckInlineIgnoreByPathIndexed_NilIndex(t *testing.T) {
 	var node yaml.Node
 	assert.False(t, checkInlineIgnoreByPathIndexed(nil, &node, "$.info", "any-rule"))
+}
+
+func TestCheckInlineIgnoreByPathIndexed_AncestorIgnore(t *testing.T) {
+	// x-lint-ignore on a parent must suppress a result reported against a child path.
+	spec := `
+openapi: 3.0.0
+components:
+  securitySchemes:
+    basicAuth:
+      x-lint-ignore: owasp-no-http-basic
+      type: http
+      scheme: basic
+`
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(spec), &node))
+
+	idx := buildInlineIgnoreIndex(&node)
+	require.NotNil(t, idx)
+	require.True(t, idx.hasNonRootIgnores)
+
+	// Path points at the child `scheme`; ignore lives on the parent object.
+	assert.True(t, checkInlineIgnoreByPathIndexed(idx, &node,
+		"$.components.securitySchemes.basicAuth.scheme", "owasp-no-http-basic"))
+	// A different rule id must not be suppressed.
+	assert.False(t, checkInlineIgnoreByPathIndexed(idx, &node,
+		"$.components.securitySchemes.basicAuth.scheme", "some-other-rule"))
 }
 
 func TestInlineIgnore_Integration_InfoDescription(t *testing.T) {
@@ -536,4 +565,62 @@ rules:
 			assert.True(t, foundIgnored, "%s should be in ignored results", spec.rule)
 		})
 	}
+}
+
+func TestInlineIgnore_Integration_OWASPNoHttpBasic(t *testing.T) {
+	spec := `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components:
+  securitySchemes:
+    ignoredBasic:
+      description: Basic auth that should be ignored.
+      x-lint-ignore: owasp-no-http-basic
+      scheme: basic
+      type: http
+    flaggedBasic:
+      description: Basic auth that should still be reported.
+      scheme: basic
+      type: http
+`
+
+	rs := &rulesets.RuleSet{
+		Rules: map[string]*model.Rule{
+			rulesets.OwaspNoHttpBasic: rulesets.GetOWASPNoHttpBasicRule(),
+		},
+	}
+
+	execution := &RuleSetExecution{
+		RuleSet:      rs,
+		Spec:         []byte(spec),
+		SpecFileName: "test.yaml",
+	}
+
+	result := ApplyRulesToRuleSet(execution)
+
+	for _, res := range result.Results {
+		assert.NotContains(t, res.Path, "ignoredBasic",
+			"ignoredBasic should be suppressed by x-lint-ignore")
+	}
+
+	var foundIgnored bool
+	for _, res := range result.IgnoredResults {
+		if res.RuleId == rulesets.OwaspNoHttpBasic {
+			foundIgnored = true
+			break
+		}
+	}
+	assert.True(t, foundIgnored, "owasp-no-http-basic should be ignored for ignoredBasic")
+
+	var foundFlagged bool
+	for _, res := range result.Results {
+		if res.RuleId == rulesets.OwaspNoHttpBasic && strings.Contains(res.Path, "flaggedBasic") {
+			foundFlagged = true
+			break
+		}
+	}
+	assert.True(t, foundFlagged, "flaggedBasic should still be reported")
 }


### PR DESCRIPTION
I ran into an issue where an `x-lint-ignore` wasn't working.
```yaml
securitySchemes:
  basicAuth:
    type: http
    scheme: basic
    x-lint-ignore: owasp-no-http-basic
```

Wasn't ignoring the `owasp-no-http-basic` error because the rule points specifically at the `scheme` key, which means the ignore at the same level isn't considered. 

So added a parent node check which will see if the ignore statement is defined on the parent so you can ignore violations like this by adding the ignore directive as a sibling to the same parent.