### PR TITLE
fix(motor): include sibling component uses in nested reference alias paths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,10 @@ Operational guide for AI agents working in `github.com/daveshanley/vacuum`.
 
 ## TL;DR
 
-- vacuum is a Go CLI and library for linting OpenAPI and JSON Schema documents, generating reports, bundling specs, running an LSP server, and generating API docs through printing press.
+- vacuum is a Go CLI and library for linting OpenAPI, AsyncAPI and JSON Schema documents, generating reports, bundling OpenAPI and JSON Schema documents where supported, running an LSP server, and generating OpenAPI docs through printing press.
 - Main entry point: `vacuum.go` -> `cmd.Execute(...)` -> `cmd.GetRootCommand()`.
-- The default OpenAPI user path is `vacuum lint <spec>`. JSON Schema linting uses `vacuum schema <schema>` or `vacuum schema lint <schema>`.
-- OpenAPI lint/report commands share helpers in `cmd/build_results.go` and `motor/`. JSON Schema command wiring lives in `cmd/schema*.go` and still executes rules through `motor/`.
+- The default OpenAPI and AsyncAPI user path is `vacuum lint <api-description>`. JSON Schema linting uses `vacuum schema <schema>` or `vacuum schema lint <schema>`.
+- OpenAPI and AsyncAPI lint/report commands share helpers in `cmd/build_results.go`, `cmd/lint_shared.go`, and `motor/`. AsyncAPI context and default-ruleset wiring lives in `asyncapi/`, `cmd/asyncapi_ruleset.go`, `motor/asyncapi_applicator.go`, and `rulesets/asyncapi_rules.go`. JSON Schema command wiring lives in `cmd/schema*.go` and still executes rules through `motor/`.
 - Go version is `1.25.0`. Node is only needed for the HTML report UI and npm package wrapper.
 - The interactive HTML report is compiled only when UI assets exist and builds use `-tags html_report_ui`.
 - Release/CI-shaped Go checks should usually run with `GOWORK=off` so local sibling checkouts do not hide committed module problems.
@@ -60,15 +60,25 @@ go test ./motor -run 'JSONSchema'
 go test ./jsonschema ./functions/jsonschema ./functions/schemachecks ./rulesets
 ```
 
+For AsyncAPI linting, ruleset, or context changes, prefer focused checks before broader package runs:
+
+```bash
+go test ./cmd -run 'AsyncAPI|Lint|Report|Dashboard|GenerateRuleset'
+go test ./motor -run 'AsyncAPI'
+go test ./asyncapi ./functions/asyncapi ./rulesets
+```
+
 ## Repo Map
 
 ```text
 vacuum.go                    binary entry point and ldflags pass-through
 cmd/                         Cobra commands, CLI flags, rendering, reports, docs and schema commands
+asyncapi/                    AsyncAPI context, detection, and libasyncapi bridge helpers
 motor/                       rule execution engine, document/index setup, result collection
 model/                       rules, result models, reports, categories, test fixtures
 rulesets/                    built-in rulesets, schemas, rule aliases, example rulesets
 functions/core/              Spectral-compatible core rule functions
+functions/asyncapi/          AsyncAPI-specific rule functions
 functions/jsonschema/        JSON Schema rule functions and synthetic validation rules
 functions/openapi/           OpenAPI-specific rule functions
 functions/owasp/             OWASP rule functions
@@ -120,6 +130,12 @@ When adding or changing flags, check every command surface that shares the behav
 - Schema mode uses `json-schema-recommended` by default, supports custom rules/functions, and must not run OpenAPI-only rules.
 - Schema bundling rewrites ordinary external `$ref` values into root `$defs`; dynamic/recursive references are preserved rather than resolved as ordinary refs.
 
+`vacuum lint` is the first-class OpenAPI and AsyncAPI surface:
+
+- OpenAPI and AsyncAPI documents use `vacuum lint <input...>` plus the `report`, `dashboard`, `html-report`, and `spectral-report` report surfaces.
+- AsyncAPI 3 documents are auto-detected and use `asyncapi-recommended` by default, or the full AsyncAPI ruleset when hard mode is enabled.
+- OpenAPI-only commands such as `bundle`, `docs`, `apply-overlay`, and `open-collection` must reject AsyncAPI clearly instead of falling through an OpenAPI path.
+
 ## Core Rules
 
 - Prefer existing command helpers in `cmd/` over creating parallel execution paths.
@@ -128,6 +144,7 @@ When adding or changing flags, check every command surface that shares the behav
 - Use `go.yaml.in/yaml/v4` where current code does; do not casually mix YAML libraries.
 - Keep rule IDs, categories, and built-in rule constants centralized in `rulesets/` and `model/`.
 - For result paths, preserve both `Path` and `Paths` semantics. Many report and diff workflows depend on stable path output.
+- For AsyncAPI, preserve `RuleFunctionContext.AsyncAPI`, libasyncapi diagnostics, node-path mapping, and the default ruleset selection path. Reports, stats, snippets, and diagnostics should remain first-class outputs.
 - For JSON Schema, preserve the schema-only Doctor path, libopenapi index/rolodex reference behavior, and low-level YAML/JSON node fidelity. Line/column, snippets, JSONPath output, and `$ref` diagnostics depend on that stack.
 - Do not remove or weaken panic recovery, timeouts, lookup timeouts, or circular-reference controls without focused tests.
 - For custom JS functions, keep fetch security defaults intact: HTTPS only unless `--allow-http`, and private network access only with `--allow-private-networks`.
@@ -145,9 +162,10 @@ When adding or changing flags, check every command surface that shares the behav
 
 - Built-in functions implement `model.RuleFunction`.
 - A function must provide `RunRule`, `GetSchema`, and `GetCategory`.
-- Tests usually live beside the function they cover: `functions/core`, `functions/openapi`, `functions/jsonschema`, `functions/schemachecks`, or `functions/owasp`.
+- Tests usually live beside the function they cover: `functions/core`, `functions/openapi`, `functions/asyncapi`, `functions/jsonschema`, `functions/schemachecks`, or `functions/owasp`.
 - Add new built-in rule IDs and docs metadata through the existing `rulesets` patterns.
 - Example rulesets belong under `rulesets/examples/`; schema changes belong under `rulesets/schemas/`.
+- AsyncAPI-specific built-ins should use `functions/asyncapi`; shared core functions are fine when the rule behavior is genuinely format-neutral.
 - JSON Schema-specific built-ins should use `functions/jsonschema`; shared schema semantics belong in `functions/schemachecks` so OpenAPI and JSON Schema do not drift.
 - Custom Go plugin behavior is demonstrated in `plugin/sample/`.
 - Custom JavaScript runtime behavior lives under `plugin/javascript/`; async, Promise, and fetch behavior should be tested there.
@@ -223,6 +241,7 @@ Check `git status --short` before editing. Preserve unrelated user changes.
 - Command behavior: add focused tests under `cmd/`.
 - Rule execution behavior: add or update tests under `motor/`.
 - Built-in rule functions: test in the relevant `functions/...` package.
+- AsyncAPI command, context, and default-ruleset behavior: test under `cmd/`, `asyncapi/`, `motor/`, `functions/asyncapi/`, and `rulesets/`.
 - JSON Schema command behavior: test under `cmd/`; dialect, metaschema, Doctor, and reference helpers: test under `jsonschema/`; schema-only motor behavior: test under `motor/`.
 - Ruleset parsing/aliases/default rules: test under `rulesets/`.
 - Language server behavior: test under `language-server/`.

--- a/motor/result_path_reconcile.go
+++ b/motor/result_path_reconcile.go
@@ -570,30 +570,98 @@ func expandResultReferenceAliasPaths(
 		return nil
 	}
 
+	targetPaths := equivalentResultReferenceTargetPaths(targetIndex, targetPath, targetPathIndex)
 	var paths []string
-	for _, ref := range sourceIndex.GetAllSequencedReferences() {
-		if ref == nil || ref.Node == nil || ref.Path == "" {
-			continue
+	for _, candidateTargetPath := range targetPaths {
+		if strings.HasPrefix(candidateTargetPath, "$.components.") {
+			paths = append(paths, candidateTargetPath)
 		}
-		if !referenceTargetsIndex(ref, targetIndex) {
-			continue
+		for _, ref := range sourceIndex.GetAllSequencedReferences() {
+			if ref == nil || ref.Node == nil || ref.Path == "" {
+				continue
+			}
+			if !referenceTargetsIndex(ref, targetIndex) {
+				continue
+			}
+			sourcePath, ok := sourcePathIndex.Lookup(ref.Node)
+			if !ok || sourcePath == "" {
+				continue
+			}
+			paths = append(paths, expandResultReferenceAliasPath(
+				ref.Path,
+				sourcePath,
+				candidateTargetPath,
+				targetIndex.GetAllSequencedReferences(),
+				targetPathIndex,
+				targetIndex,
+				nil,
+				0,
+			)...)
 		}
-		sourcePath, ok := sourcePathIndex.Lookup(ref.Node)
-		if !ok || sourcePath == "" {
-			continue
-		}
-		paths = append(paths, expandResultReferenceAliasPath(
-			ref.Path,
-			sourcePath,
-			targetPath,
-			targetIndex.GetAllSequencedReferences(),
-			targetPathIndex,
-			targetIndex,
-			nil,
-			0,
-		)...)
 	}
 	return uniqueSortedResultPaths(paths)
+}
+
+func equivalentResultReferenceTargetPaths(
+	targetIndex *index.SpecIndex,
+	targetPath string,
+	targetPathIndex *vacuumUtils.NodePathIndex,
+) []string {
+	if targetIndex == nil || targetPath == "" || targetPathIndex == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var paths []string
+	type queuedPath struct {
+		path  string
+		depth int
+	}
+
+	var queue []queuedPath
+
+	add := func(path string, depth int) {
+		if path == "" {
+			return
+		}
+		path = canonicalizeResultAliasPath(path)
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+		if depth < maxResultReferenceAliasDepth {
+			queue = append(queue, queuedPath{path: path, depth: depth})
+		}
+	}
+
+	add(targetPath, 0)
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, ref := range targetIndex.GetAllSequencedReferences() {
+			if ref == nil || ref.Node == nil || ref.Path == "" {
+				continue
+			}
+			if !referenceTargetsIndex(ref, targetIndex) {
+				continue
+			}
+
+			sourcePath, ok := targetPathIndex.Lookup(ref.Node)
+			if !ok || sourcePath == "" {
+				continue
+			}
+			suffix, ok := trimAliasPathPrefix(current.path, sourcePath)
+			if !ok {
+				continue
+			}
+			add(ref.Path+suffix, current.depth+1)
+		}
+	}
+
+	sort.Strings(paths)
+	return paths
 }
 
 func expandResultReferenceAliasPath(

--- a/motor/result_path_reconcile_test.go
+++ b/motor/result_path_reconcile_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/daveshanley/vacuum/model"
 	"github.com/daveshanley/vacuum/rulesets"
+	vacuumUtils "github.com/daveshanley/vacuum/utils"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -313,6 +314,92 @@ func TestIssue879RecursiveAllOfSiblingReferencePathsAreCompleteAndStable(t *test
 				assert.Equal(t, expectedEnumPaths, enumResult.Paths, "GOMAXPROCS=%d iteration %d", procs, i)
 			}
 		}
+	}
+}
+
+func TestIssue879RecursiveNestedReferenceAliasesIncludeSiblingComponentUses(t *testing.T) {
+	dir, specPath, specBytes := writeIssue879NestedReferenceAliasFixture(t)
+
+	rule := &model.Rule{
+		Id:          "repro-string-min-length",
+		Description: "Every string must declare minLength",
+		Message:     "String is missing minLength",
+		Given:       "$..[?(@ && @.type && @.type == 'string')]",
+		Resolved:    true,
+		Severity:    model.SeverityError,
+		Then: &model.RuleAction{
+			Field:    "minLength",
+			Function: "defined",
+		},
+	}
+	ruleSet := &rulesets.RuleSet{Rules: map[string]*model.Rule{rule.Id: rule}}
+
+	expectedPaths := []string{
+		"$.components.schemas['vesselSurveyResult'].allOf[1].allOf[2].properties['hullIdentificationNumber'].allOf[0]",
+		"$.paths['/v1/vesselSurveys'].post.requestBody.content['application/json'].schema.allOf[2].properties['hullIdentificationNumber'].allOf[0]",
+		"$.paths['/v1/vesselSurveys'].post.responses['201'].content['application/json'].schema.allOf[1].allOf[2].properties['hullIdentificationNumber'].allOf[0]",
+	}
+
+	previousProcs := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(previousProcs)
+
+	for _, procs := range []int{1, 4} {
+		runtime.GOMAXPROCS(procs)
+		for i := 0; i < 50; i++ {
+			results := ApplyRulesToRuleSet(&RuleSetExecution{
+				RuleSet:           ruleSet,
+				Spec:              specBytes,
+				SpecFileName:      specPath,
+				Base:              dir,
+				AllowLookup:       true,
+				NodeLookupTimeout: 5 * time.Second,
+				SilenceLogs:       true,
+			})
+
+			require.Empty(t, results.Errors, "GOMAXPROCS=%d iteration %d", procs, i)
+
+			result := findResultByRuleAndPath(results.Results, rule.Id, expectedPaths[0])
+			if assert.NotNil(t, result, "GOMAXPROCS=%d iteration %d", procs, i) {
+				assert.Equal(t, expectedPaths, result.Paths, "GOMAXPROCS=%d iteration %d", procs, i)
+			}
+		}
+	}
+}
+
+func TestEquivalentResultReferenceTargetPathsStopsOnDescendantReferenceCycle(t *testing.T) {
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(`openapi: 3.0.3
+info:
+  title: descendant reference cycle
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Loop:
+      $ref: '#/components/schemas/Loop/properties/next'
+      properties:
+        next:
+          type: object
+`), &root))
+
+	cfg := index.CreateOpenAPIIndexConfig()
+	idx := index.NewSpecIndexWithConfig(&root, cfg)
+	idx.BuildIndex()
+	pathIndex := resultPathIndexForSpec(idx, make(map[*index.SpecIndex]*vacuumUtils.NodePathIndex))
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- equivalentResultReferenceTargetPaths(idx, "$.components.schemas['Loop']", pathIndex)
+	}()
+
+	select {
+	case paths := <-done:
+		require.NotEmpty(t, paths)
+		assert.Contains(t, paths, "$.components.schemas['Loop']")
+		assert.Contains(t, paths, "$.components.schemas['Loop'].properties['next']")
+		assert.LessOrEqual(t, len(paths), maxResultReferenceAliasDepth+1)
+	case <-time.After(time.Second):
+		t.Fatal("equivalentResultReferenceTargetPaths did not terminate")
 	}
 }
 
@@ -863,6 +950,71 @@ components:
           type: string
           enum:
             - pending
+`)
+	require.NoError(t, os.WriteFile(specPath, specBytes, 0644))
+	return dir, specPath, specBytes
+}
+
+func writeIssue879NestedReferenceAliasFixture(t *testing.T) (string, string, []byte) {
+	t.Helper()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "openapi-test.yaml")
+
+	specBytes := []byte(`openapi: 3.0.3
+info:
+  title: Vacuum issue 879 marine nested alias repro
+  version: 1.0.0
+paths:
+  /v1/vesselSurveys:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/vesselSurvey'
+      responses:
+        '201':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/vesselSurveyResult'
+components:
+  schemas:
+    vesselSurvey:
+      allOf:
+        - $ref: '#/components/schemas/vesselProfile'
+        - $ref: '#/components/schemas/harborContact'
+        - type: object
+          properties:
+            hullIdentificationNumber:
+              description: Primary hull identifier for the vessel
+              $ref: '#/components/schemas/nauticalIdentifier'
+    vesselSurveyResult:
+      allOf:
+        - $ref: '#/components/schemas/surveyRecord'
+        - $ref: '#/components/schemas/vesselSurvey'
+    vesselProfile:
+      type: object
+      properties:
+        vesselName:
+          type: string
+          minLength: 1
+    harborContact:
+      type: object
+      properties:
+        harborMaster:
+          type: string
+          minLength: 1
+    surveyRecord:
+      type: object
+      properties:
+        surveyId:
+          type: string
+          minLength: 1
+    nauticalIdentifier:
+      type: string
 `)
 	require.NoError(t, os.WriteFile(specPath, specBytes, 0644))
 	return dir, specPath, specBytes


### PR DESCRIPTION
Resolve issue #879 where recursive nested reference aliases dropped sibling component uses from result paths. Add equivalentResultReferenceTargetPaths to walk equivalent target paths via BFS, emit component paths, and bound traversal with depth limiting to terminate on descendant reference cycles.