### PR TITLE
case-insensitive category matching and warn when --fix applies no fixes

### DIFF
--- a/cmd/lint_cmd.go
+++ b/cmd/lint_cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/daveshanley/vacuum/motor"
 	"github.com/daveshanley/vacuum/rulesets"
 	"github.com/daveshanley/vacuum/statistics"
+	"github.com/daveshanley/vacuum/tui"
 	"github.com/daveshanley/vacuum/utils"
 )
 
@@ -363,31 +364,10 @@ func runLint(cmd *cobra.Command, args []string) error {
 	if flags.CategoryFlag != "" {
 		resultSet.ResetCounts()
 		var filteredResults []*model.RuleFunctionResult
-		switch flags.CategoryFlag {
-		case model.CategoryDescriptions:
-			cats = append(cats, model.RuleCategories[model.CategoryDescriptions])
-		case model.CategoryExamples:
-			cats = append(cats, model.RuleCategories[model.CategoryExamples])
-		case model.CategoryInfo:
-			cats = append(cats, model.RuleCategories[model.CategoryInfo])
-		case model.CategorySchemas:
-			cats = append(cats, model.RuleCategories[model.CategorySchemas])
-		case model.CategorySecurity:
-			cats = append(cats, model.RuleCategories[model.CategorySecurity])
-		case model.CategoryValidation:
-			cats = append(cats, model.RuleCategories[model.CategoryValidation])
-		case model.CategoryOperations:
-			cats = append(cats, model.RuleCategories[model.CategoryOperations])
-		case model.CategoryTags:
-			cats = append(cats, model.RuleCategories[model.CategoryTags])
-		case model.CategoryOWASP:
-			cats = append(cats, model.RuleCategories[model.CategoryOWASP])
-		default:
-			if !flags.SilentFlag {
-				fmt.Printf("%sWarning: Category '%s' is unknown, all categories are being considered.%s\n\n",
-					color.ASCIIYellow, flags.CategoryFlag, color.ASCIIReset)
-			}
-			cats = model.RuleCategoriesOrdered
+		var knownCategory bool
+		cats, knownCategory = resolveLintCategoryFlag(flags.CategoryFlag)
+		if !knownCategory {
+			renderLintWarning(flags, "Category '%s' is unknown, all categories are being considered.", flags.CategoryFlag)
 		}
 		// filter results by category
 		for _, val := range cats {
@@ -406,6 +386,8 @@ func runLint(cmd *cobra.Command, args []string) error {
 	}
 
 	resultSet.SortResultsByLineNumber()
+
+	renderNoFixesAppliedWarning(flags, resultSet, fixesApplied)
 
 	if reportOrSpec.IsReport && reportOrSpec.Report.Statistics != nil {
 		stats = reportOrSpec.Report.Statistics
@@ -486,6 +468,63 @@ func runLint(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func resolveLintCategoryFlag(categoryFlag string) ([]*model.RuleCategory, bool) {
+	categoryFlag = strings.TrimSpace(categoryFlag)
+	if categoryFlag == "" {
+		return model.RuleCategoriesOrdered, true
+	}
+	if matchesRuleCategory(model.RuleCategories[model.CategoryAll], categoryFlag) {
+		return model.RuleCategoriesOrdered, true
+	}
+	for _, category := range model.RuleCategoriesOrdered {
+		if matchesRuleCategory(category, categoryFlag) {
+			return []*model.RuleCategory{category}, true
+		}
+	}
+	return model.RuleCategoriesOrdered, false
+}
+
+func matchesRuleCategory(category *model.RuleCategory, categoryFlag string) bool {
+	if category == nil {
+		return false
+	}
+	return strings.EqualFold(categoryFlag, category.Id) || strings.EqualFold(categoryFlag, category.Name)
+}
+
+func renderNoFixesAppliedWarning(flags *LintFlags, resultSet *model.RuleResultSet, fixesApplied int) {
+	if flags == nil || resultSet == nil {
+		return
+	}
+	if !flags.FixFlag || fixesApplied > 0 || len(resultSet.Results) == 0 {
+		return
+	}
+	messagePrefix := "No fixes were applied"
+	if flags.FixFileFlag != "" {
+		messagePrefix = fmt.Sprintf("No fixes were written to '%s'", flags.FixFileFlag)
+	}
+	if hasAutoFixableResults(resultSet.Results) {
+		renderLintWarning(flags, "%s; no auto-fixes were applied.", messagePrefix)
+		return
+	}
+	renderLintWarning(flags, "%s; none of the reported violations support auto-fix.", messagePrefix)
+}
+
+func hasAutoFixableResults(results []*model.RuleFunctionResult) bool {
+	for _, result := range results {
+		if result != nil && result.Rule != nil && result.Rule.AutoFixFunction != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderLintWarning(flags *LintFlags, format string, args ...any) {
+	if flags == nil || flags.SilentFlag || flags.PipelineOutput {
+		return
+	}
+	tui.RenderWarning(format, args...)
 }
 
 // fileResult holds the results and logs for a single file

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/daveshanley/vacuum/model"
 	"github.com/pb33f/testify/assert"
 	"github.com/pb33f/testify/require"
 )
@@ -124,6 +126,152 @@ func TestGetLintCommand_WithVacuumReport(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.NoError(t, err)
+}
+
+func TestResolveLintCategoryFlagIsCaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantID string
+	}{
+		{name: "lowercase id", input: "tags", wantID: model.CategoryTags},
+		{name: "display name", input: "Tags", wantID: model.CategoryTags},
+		{name: "uppercase id", input: "TAGS", wantID: model.CategoryTags},
+		{name: "mixed case display name", input: "ScHeMaS", wantID: model.CategorySchemas},
+		{name: "multi word display name", input: "contract information", wantID: model.CategoryInfo},
+		{name: "owasp lowercase", input: "owasp", wantID: model.CategoryOWASP},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			categories, ok := resolveLintCategoryFlag(tt.input)
+
+			require.True(t, ok)
+			require.Len(t, categories, 1)
+			assert.Equal(t, tt.wantID, categories[0].Id)
+		})
+	}
+}
+
+func TestResolveLintCategoryFlagUnknownFallsBackToAllCategories(t *testing.T) {
+	categories, ok := resolveLintCategoryFlag("not-a-real-category")
+
+	assert.False(t, ok)
+	assert.Equal(t, model.RuleCategoriesOrdered, categories)
+}
+
+func TestGetLintCommand_FixFileWarnsWhenNoReportedViolationsSupportAutoFix(t *testing.T) {
+	cmd := GetLintCommand()
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+
+	fixPath := filepath.Join(t.TempDir(), "fixed.yaml")
+	cmd.SetArgs([]string{
+		"--no-banner",
+		"--no-style",
+		"--fix",
+		"--fix-file", fixPath,
+		"../model/test_files/burgershop.openapi.yaml",
+	})
+
+	var err error
+	stdout, stderr := captureOSStreams(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err)
+	output := stdout + stderr + b.String()
+	assert.Contains(t, output, "▲ No fixes were written to")
+	assert.Contains(t, output, fixPath)
+	assert.Contains(t, output, "none of the reported violations support auto-fix")
+
+	_, statErr := os.Stat(fixPath)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestGetLintCommand_FixWarnsWhenNoReportedViolationsSupportAutoFix(t *testing.T) {
+	cmd := GetLintCommand()
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+	cmd.SetArgs([]string{
+		"--no-banner",
+		"--no-style",
+		"--fix",
+		"../model/test_files/burgershop.openapi.yaml",
+	})
+
+	var err error
+	stdout, stderr := captureOSStreams(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err)
+	output := stdout + stderr + b.String()
+	assert.Contains(t, output, "▲ No fixes were applied")
+	assert.Contains(t, output, "none of the reported violations support auto-fix")
+}
+
+func TestRenderNoFixesAppliedWarningRespectsOutputMode(t *testing.T) {
+	resultSet := &model.RuleResultSet{
+		Results: []*model.RuleFunctionResult{
+			{Rule: &model.Rule{}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		flags      *LintFlags
+		wantOutput bool
+	}{
+		{
+			name: "normal terminal output",
+			flags: &LintFlags{
+				FixFlag:     true,
+				FixFileFlag: "fixed.yaml",
+			},
+			wantOutput: true,
+		},
+		{
+			name: "silent suppresses warning",
+			flags: &LintFlags{
+				FixFlag:     true,
+				FixFileFlag: "fixed.yaml",
+				SilentFlag:  true,
+			},
+		},
+		{
+			name: "pipeline output suppresses warning",
+			flags: &LintFlags{
+				FixFlag:        true,
+				FixFileFlag:    "fixed.yaml",
+				PipelineOutput: true,
+			},
+		},
+		{
+			name: "fix without fix file warns",
+			flags: &LintFlags{
+				FixFlag: true,
+			},
+			wantOutput: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr := captureOSStreams(t, func() {
+				renderNoFixesAppliedWarning(tt.flags, resultSet, 0)
+			})
+
+			output := stdout + stderr
+			if tt.wantOutput {
+				assert.Contains(t, output, "No fixes were")
+				return
+			}
+			assert.Empty(t, output)
+		})
+	}
 }
 
 func TestGetLintCommand_QuotedResponseExampleDoesNotReportMarshalIssues(t *testing.T) {


### PR DESCRIPTION
Replace the hardcoded category switch with resolveLintCategoryFlag, which matches the --category flag against category IDs and display names case-insensitively and falls back to all categories (with a warning) when the value is unknown.

Add `renderNoFixesAppliedWarning` so that running with --fix (or --fix-file) emits a warning when violations are reported but no fixes were applied, distinguishing between "no auto-fixes were applied" and "none of the reported violations support auto-fix". Warnings are suppressed in silent and pipeline output modes.

Add tests covering case-insensitive category resolution, the unknown category fallback, and no-fix warning behavior across output modes.