### PR TITLE
Sign release checksums with cosign

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,9 @@ jobs:
   release_and_brew:
     name: Release and bump homebrew version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Free Disk Space
@@ -38,6 +41,9 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: html-report/ui/package-lock.json
+
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,16 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+signs:
+  - artifacts: checksum
+    signature: ${artifact}.sigstore.json
+    cmd: cosign
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - --yes
+      - ${artifact}
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Refs
- https://www.sigstore.dev
- https://docs.sigstore.dev/cosign/signing/overview/
- https://github.com/sigstore/cosign

This yields a checksums.txt.sigstore.json in release assets, which can be used to verify the checksums file and thus transitively files listed in it. This can be done manually using cosign, and software such as [aqua](https://aquaproj.github.io/) and [mise](https://mise.jdx.dev/) can do it automatically on install.

Note: with this, one likely wants to use `--skip=sign` if running `goreleaser release --snapshot` to test (other) things locally.