### PR TITLE
Add family-aware docs diagnostics and service contract navigation

### DIFF
--- a/cmd/asyncapi_test.go
+++ b/cmd/asyncapi_test.go
@@ -6,15 +6,19 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"html"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/daveshanley/vacuum/model"
 	"github.com/daveshanley/vacuum/rulesets"
 	"github.com/daveshanley/vacuum/utils"
+	ppmodel "github.com/pb33f/doctor/printingpress/model"
 	"github.com/pb33f/testify/assert"
 	"github.com/pb33f/testify/require"
 )
@@ -235,6 +239,173 @@ paths: {}`)
 	assert.Contains(t, string(indexHTML), "services/openapi/")
 	assert.Contains(t, string(indexHTML), "services/asyncapi/")
 	assert.True(t, docsOutputContainsFile(t, outputDir, "asyncapi.yaml"))
+}
+
+func TestRunDocsAggregateGroupsMixedContractsWithFamilyDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	openAPIPath := filepath.Join(root, "services", "generic", "http", "v1", "openapi.yaml")
+	asyncAPIPath := filepath.Join(root, "services", "generic", "events", "v1", "asyncapi.yaml")
+	writeTestFile(t, openAPIPath, `openapi: 3.1.0
+info:
+  title: Generic Catalog HTTP API
+  version: 1.0.0
+  description: HTTP contract.
+  x-owner:
+    service: Generic Catalog
+paths: {}
+`)
+	writeTestFile(t, asyncAPIPath, `asyncapi: 3.1.0
+info:
+  title: Generic Catalog Published Events
+  version: 1.0.0
+  description: Published event contract.
+  x-owner:
+    service: Generic Catalog
+tags:
+  - name: events
+    description: Published events.
+servers:
+  production:
+    host: broker.example.net
+    protocol: mqtt
+channels: {}
+operations: {}
+`)
+
+	configPath := filepath.Join(root, "printing-press.yaml")
+	writeTestFile(t, configPath, `grouping:
+  serviceIdentity:
+    metadataPointers:
+      - /info/x-owner/service
+  contractRoles:
+    - pattern: "**/http/**"
+      role: http-api
+      contractID: http-api
+      default: true
+    - pattern: "**/events/**"
+      role: published-events
+      contractID: published-events
+`)
+	openAPIRuleset := writeDocsNamedRuleset(t, root, "openapi-ruleset.yaml", "custom-openapi-family-rule")
+	outputDir := filepath.Join(t.TempDir(), "docs")
+	cmd := GetDocsCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := runDocs(cmd, root, &docsOptions{
+		outputDir:      outputDir,
+		docsConfigPath: configPath,
+		openAPIRuleset: openAPIRuleset,
+		noLLM:          true,
+		noJSON:         true,
+		noLogo:         true,
+		includeSpec:    true,
+	})
+
+	require.NoError(t, err)
+	catalogHTML, err := os.ReadFile(filepath.Join(outputDir, "index.html"))
+	require.NoError(t, err)
+	defaultHTTPHref := "services/generic-catalog/versions/1-0-0/specs/generic-catalog-http-api/index.html"
+	assert.Contains(t, string(catalogHTML), `href="`+defaultHTTPHref+`"`)
+
+	serviceSpecsRoot := filepath.Join(outputDir, "services", "generic-catalog", "versions", "1-0-0", "specs")
+	httpRoot := filepath.Join(serviceSpecsRoot, "generic-catalog-http-api")
+	eventRoot := filepath.Join(serviceSpecsRoot, "generic-catalog-published-events")
+	httpOverview := readDocsContractPage(t, filepath.Join(httpRoot, "index.html"))
+	assert.Equal(t, "API OVERVIEW", httpOverview.overviewLabel)
+	assert.Equal(t, "Generic Catalog HTTP API", httpOverview.serviceName)
+	assertDocsContractTree(t, httpOverview.groups, "http-api")
+
+	eventOverview := readDocsContractPage(t, filepath.Join(eventRoot, "index.html"))
+	assert.Equal(t, "EVENT OVERVIEW", eventOverview.overviewLabel)
+	assert.Equal(t, "Generic Catalog HTTP API", eventOverview.serviceName)
+	assertDocsContractTree(t, eventOverview.groups, "published-events")
+
+	openAPIDiagnostics := readTestFile(t, filepath.Join(httpRoot, "data", "pages", "diagnostics.js"))
+	assert.Contains(t, openAPIDiagnostics, "custom-openapi-family-rule")
+	assert.NotContains(t, openAPIDiagnostics, rulesets.AsyncAPIInfoContact)
+	asyncAPIDiagnostics := readTestFile(t, filepath.Join(eventRoot, "data", "pages", "diagnostics.js"))
+	assert.Contains(t, asyncAPIDiagnostics, rulesets.AsyncAPIInfoContact)
+	assert.NotContains(t, asyncAPIDiagnostics, "custom-openapi-family-rule")
+
+	legacyRuleset := writeDocsNamedRuleset(t, root, "legacy-ruleset.yaml", "legacy-docs-rule")
+	legacyOutput := filepath.Join(t.TempDir(), "legacy-docs")
+	legacyCmd := GetDocsCommand()
+	legacyCmd.SetOut(io.Discard)
+	legacyCmd.SetErr(io.Discard)
+	legacyCmd.Flags().String("ruleset", "", "")
+	require.NoError(t, legacyCmd.Flags().Set("ruleset", legacyRuleset))
+	legacyFlags := docsLintFlags(legacyCmd)
+	assert.Equal(t, legacyRuleset, legacyFlags.RulesetFlag)
+	legacyDiagnostics, err := newDocsDiagnosticsContext(legacyFlags, utils.HTTPClientConfig{}, nil, true)
+	require.NoError(t, err)
+	legacyResults, err := legacyDiagnostics.lintSpec([]byte(docsDiagnosticsSpec("Legacy HTTP API")), openAPIPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, legacyResults)
+	assert.Equal(t, "legacy-docs-rule", legacyResults[0].RuleId)
+	require.NoError(t, runDocs(legacyCmd, root, &docsOptions{
+		outputDir:      legacyOutput,
+		docsConfigPath: configPath,
+		noLLM:          true,
+		noJSON:         true,
+		noLogo:         true,
+	}))
+	legacyDiagnosticsPath := filepath.Join(legacyOutput, "services", "generic-catalog", "versions", "1-0-0", "specs", "generic-catalog-http-api", "data", "pages", "diagnostics.js")
+	assert.Contains(t, readTestFile(t, legacyDiagnosticsPath), "legacy-docs-rule")
+}
+
+type docsContractPage struct {
+	overviewLabel string
+	serviceName   string
+	groups        []*ppmodel.SiteContractGroup
+}
+
+func readDocsContractPage(t *testing.T, pagePath string) docsContractPage {
+	t.Helper()
+	rendered := readTestFile(t, pagePath)
+	contractPayload := docsHTMLAttribute(t, rendered, "data-pp-contracts")
+	var groups []*ppmodel.SiteContractGroup
+	require.NoError(t, json.Unmarshal([]byte(contractPayload), &groups))
+	return docsContractPage{
+		overviewLabel: docsHTMLAttribute(t, rendered, "data-pp-overview-label"),
+		serviceName:   docsHTMLAttribute(t, rendered, "data-pp-service-name"),
+		groups:        groups,
+	}
+}
+
+func docsHTMLAttribute(t *testing.T, rendered, name string) string {
+	t.Helper()
+	marker := name + `="`
+	start := strings.Index(rendered, marker)
+	require.GreaterOrEqual(t, start, 0, "missing %s", name)
+	valueStart := start + len(marker)
+	valueEnd := strings.Index(rendered[valueStart:], `"`)
+	require.GreaterOrEqual(t, valueEnd, 0, "unterminated %s", name)
+	return html.UnescapeString(rendered[valueStart : valueStart+valueEnd])
+}
+
+func assertDocsContractTree(t *testing.T, groups []*ppmodel.SiteContractGroup, activeRole string) {
+	t.Helper()
+	require.Len(t, groups, 2)
+	assert.Equal(t, ppmodel.ContractRoleHTTPAPI, groups[0].Role)
+	assert.Equal(t, "HTTP API", groups[0].Label)
+	require.Len(t, groups[0].Contracts, 1)
+	assert.Equal(t, "http-api", groups[0].Contracts[0].ID)
+	assert.Equal(t, "Generic Catalog HTTP API", groups[0].Contracts[0].Label)
+	assert.Equal(t, activeRole == "http-api", groups[0].Contracts[0].Active)
+	assert.Equal(t, ppmodel.ContractRolePublishedEvents, groups[1].Role)
+	assert.Equal(t, "Published Events", groups[1].Label)
+	require.Len(t, groups[1].Contracts, 1)
+	assert.Equal(t, "published-events", groups[1].Contracts[0].ID)
+	assert.Equal(t, "Generic Catalog Published Events", groups[1].Contracts[0].Label)
+	assert.Equal(t, activeRole == "published-events", groups[1].Contracts[0].Active)
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
 }
 
 func docsOutputContainsFile(t *testing.T, root, name string) bool {

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -64,6 +64,8 @@ The source API contract is not shipped in generated output by default. Use
 	cmd.Flags().StringVar(&opts.title, "title", "", "Override the API title")
 	cmd.Flags().StringVar(&opts.catalogTitle, "catalog-title", "", "Override the API catalog title")
 	cmd.Flags().StringVar(&opts.docsConfigPath, "docs-config", "", "Path to a printing press docs config file")
+	cmd.Flags().StringVar(&opts.openAPIRuleset, "openapi-ruleset", "", "Ruleset for OpenAPI docs diagnostics")
+	cmd.Flags().StringVar(&opts.asyncAPIRuleset, "asyncapi-ruleset", "", "Ruleset for AsyncAPI docs diagnostics")
 	cmd.Flags().StringVar(&opts.baseURL, "base-url", "", "Base URL to use in generated HTML")
 	cmd.Flags().StringVar(&opts.basePath, "base-path", "", "Base path for resolving local file references")
 	cmd.Flags().StringVar(&opts.buildMode, "build-mode", "", "Aggregate build mode: full, fast, or watch")
@@ -136,7 +138,7 @@ func runDocs(cmd *cobra.Command, input string, opts *docsOptions) (err error) {
 		if err != nil {
 			return err
 		}
-		diagnostics, err := newDocsDiagnosticsContext(lintFlags, httpClientConfig, fetchConfig, !opts.noDiagnostics)
+		diagnostics, err := newDocsDiagnosticsContext(lintFlags, httpClientConfig, fetchConfig, !opts.noDiagnostics, docsFamilyRulesetPathsFromOptions(opts))
 		if err != nil {
 			return err
 		}
@@ -151,7 +153,7 @@ func runDocs(cmd *cobra.Command, input string, opts *docsOptions) (err error) {
 	if err != nil {
 		return err
 	}
-	diagnostics, err := newDocsDiagnosticsContext(lintFlags, httpClientConfig, fetchConfig, !opts.noDiagnostics)
+	diagnostics, err := newDocsDiagnosticsContext(lintFlags, httpClientConfig, fetchConfig, !opts.noDiagnostics, docsFamilyRulesetPathsFromOptions(opts))
 	if err != nil {
 		return err
 	}

--- a/cmd/docs_config.go
+++ b/cmd/docs_config.go
@@ -18,6 +18,8 @@ type docsOptions struct {
 	baseURL                            string
 	basePath                           string
 	docsConfigPath                     string
+	openAPIRuleset                     string
+	asyncAPIRuleset                    string
 	buildMode                          string
 	maxPools                           int
 	workersPerPool                     int

--- a/cmd/docs_diagnostics.go
+++ b/cmd/docs_diagnostics.go
@@ -35,6 +35,7 @@ type docsDiagnosticsContext struct {
 	openAPIRuleset   *rulesets.RuleSet
 	asyncAPIRuleset  *rulesets.RuleSet
 	familyRulesets   docsFamilyRulesets
+	fallbackRulesets docsFamilyRulesets
 	customFunctions  map[string]model.RuleFunction
 	ignoredItems     model.IgnoredItems
 	httpClientConfig utils.HTTPClientConfig
@@ -122,7 +123,11 @@ func newDocsDiagnosticsContext(flags *LintFlags, httpClientConfig utils.HTTPClie
 
 	ctx.customFunctions = customFunctions
 	ctx.ignoredItems = ignoredItems
-	ctx.fingerprint = docsDiagnosticsFingerprint(true, clonedFlags, ctx.legacyRuleset, ctx.familyRulesets)
+	ctx.fallbackRulesets = docsFamilyRulesets{
+		openAPI:  buildDocsDefaultRuleset(press.SpecKindOpenAPI, clonedFlags),
+		asyncAPI: buildDocsDefaultRuleset(press.SpecKindAsyncAPI, clonedFlags),
+	}
+	ctx.fingerprint = docsDiagnosticsFingerprint(true, clonedFlags, ctx.legacyRuleset, ctx.familyRulesets, ctx.fallbackRulesets)
 	return ctx, nil
 }
 
@@ -218,6 +223,16 @@ func (d *docsDiagnosticsContext) ruleSetForSpec(specBytes []byte) (*rulesets.Rul
 	}
 	if d.legacyRuleset != nil {
 		return d.legacyRuleset, nil
+	}
+	switch identity.Kind {
+	case press.SpecKindOpenAPI:
+		if d.fallbackRulesets.openAPI != nil {
+			return d.fallbackRulesets.openAPI, nil
+		}
+	case press.SpecKindAsyncAPI:
+		if d.fallbackRulesets.asyncAPI != nil {
+			return d.fallbackRulesets.asyncAPI, nil
+		}
 	}
 	return buildDocsDefaultRuleset(identity.Kind, d.flags), nil
 }
@@ -375,6 +390,10 @@ func docsDiagnosticsFingerprint(enabled bool, flags *LintFlags, selectedRS *rule
 		if len(family) > 0 {
 			payload["openapiRuleset"] = docsRulesetFingerprintIdentity(family[0].openAPIPath, family[0].openAPI)
 			payload["asyncapiRuleset"] = docsRulesetFingerprintIdentity(family[0].asyncAPIPath, family[0].asyncAPI)
+		}
+		if len(family) > 1 {
+			payload["openapiFallbackRuleset"] = docsCanonicalRuleSet(family[1].openAPI)
+			payload["asyncapiFallbackRuleset"] = docsCanonicalRuleSet(family[1].asyncAPI)
 		}
 		if flags != nil {
 			payload["ignoreFile"] = docsPathFingerprint(flags.IgnoreFile)

--- a/cmd/docs_diagnostics.go
+++ b/cmd/docs_diagnostics.go
@@ -22,6 +22,7 @@ import (
 	"github.com/daveshanley/vacuum/rulesets"
 	"github.com/daveshanley/vacuum/utils"
 	doctorV3 "github.com/pb33f/doctor/model/high/v3"
+	press "github.com/pb33f/doctor/printingpress"
 	ppmodel "github.com/pb33f/doctor/printingpress/model"
 	"golang.org/x/sync/errgroup"
 )
@@ -30,6 +31,10 @@ type docsDiagnosticsContext struct {
 	enabled          bool
 	flags            *LintFlags
 	selectedRuleset  *rulesets.RuleSet
+	legacyRuleset    *rulesets.RuleSet
+	openAPIRuleset   *rulesets.RuleSet
+	asyncAPIRuleset  *rulesets.RuleSet
+	familyRulesets   docsFamilyRulesets
 	customFunctions  map[string]model.RuleFunction
 	ignoredItems     model.IgnoredItems
 	httpClientConfig utils.HTTPClientConfig
@@ -37,38 +42,102 @@ type docsDiagnosticsContext struct {
 	fingerprint      string
 }
 
+type docsFamilyRulesetPaths struct {
+	openAPI  string
+	asyncAPI string
+}
+
+type docsFamilyRulesets struct {
+	openAPIPath  string
+	openAPI      *rulesets.RuleSet
+	asyncAPIPath string
+	asyncAPI     *rulesets.RuleSet
+}
+
+func docsFamilyRulesetPathsFromOptions(opts *docsOptions) docsFamilyRulesetPaths {
+	if opts == nil {
+		return docsFamilyRulesetPaths{}
+	}
+	return docsFamilyRulesetPaths{
+		openAPI:  opts.openAPIRuleset,
+		asyncAPI: opts.asyncAPIRuleset,
+	}
+}
+
 type docsDiagnosticsProgressFunc func(completed, total int, currentSpec string, elapsed time.Duration)
 
-func newDocsDiagnosticsContext(flags *LintFlags, httpClientConfig utils.HTTPClientConfig, fetchConfig *utils.FetchConfig, enabled bool) (*docsDiagnosticsContext, error) {
+func newDocsDiagnosticsContext(flags *LintFlags, httpClientConfig utils.HTTPClientConfig, fetchConfig *utils.FetchConfig, enabled bool, configured ...docsFamilyRulesetPaths) (*docsDiagnosticsContext, error) {
+	clonedFlags := cloneDocsLintFlags(flags)
+	familyPaths := docsFamilyRulesetPaths{}
+	if len(configured) > 0 {
+		familyPaths = configured[0]
+	}
 	ctx := &docsDiagnosticsContext{
 		enabled:          enabled,
-		flags:            flags,
+		flags:            clonedFlags,
 		httpClientConfig: httpClientConfig,
 		fetchConfig:      fetchConfig,
+		familyRulesets: docsFamilyRulesets{
+			openAPIPath:  strings.TrimSpace(familyPaths.openAPI),
+			asyncAPIPath: strings.TrimSpace(familyPaths.asyncAPI),
+		},
 	}
 	if !enabled {
-		ctx.fingerprint = docsDiagnosticsFingerprint(false, flags, nil)
+		ctx.fingerprint = docsDiagnosticsFingerprint(false, clonedFlags, nil)
 		return ctx, nil
 	}
 
-	selectedRS, err := LoadRulesetWithConfig(flags, slog.Default())
-	if err != nil {
-		return nil, fmt.Errorf("unable to load diagnostics ruleset: %w", err)
+	if strings.TrimSpace(clonedFlags.RulesetFlag) != "" {
+		selectedRS, err := loadDocsDiagnosticsRuleset(clonedFlags, clonedFlags.RulesetFlag)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load legacy diagnostics ruleset: %w", err)
+		}
+		ctx.selectedRuleset = selectedRS
+		ctx.legacyRuleset = selectedRS
 	}
-	customFunctions, err := LoadCustomFunctions(flags.FunctionsFlag, true)
+	if ctx.familyRulesets.openAPIPath != "" {
+		selectedRS, err := loadDocsDiagnosticsRuleset(clonedFlags, ctx.familyRulesets.openAPIPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load OpenAPI diagnostics ruleset: %w", err)
+		}
+		ctx.openAPIRuleset = selectedRS
+		ctx.familyRulesets.openAPI = selectedRS
+	}
+	if ctx.familyRulesets.asyncAPIPath != "" {
+		selectedRS, err := loadDocsDiagnosticsRuleset(clonedFlags, ctx.familyRulesets.asyncAPIPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load AsyncAPI diagnostics ruleset: %w", err)
+		}
+		ctx.asyncAPIRuleset = selectedRS
+		ctx.familyRulesets.asyncAPI = selectedRS
+	}
+	customFunctions, err := LoadCustomFunctions(clonedFlags.FunctionsFlag, true)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load custom functions: %w", err)
 	}
-	ignoredItems, err := LoadIgnoreFile(flags.IgnoreFile, true, true, true)
+	ignoredItems, err := LoadIgnoreFile(clonedFlags.IgnoreFile, true, true, true)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx.selectedRuleset = selectedRS
 	ctx.customFunctions = customFunctions
 	ctx.ignoredItems = ignoredItems
-	ctx.fingerprint = docsDiagnosticsFingerprint(true, flags, selectedRS)
+	ctx.fingerprint = docsDiagnosticsFingerprint(true, clonedFlags, ctx.legacyRuleset, ctx.familyRulesets)
 	return ctx, nil
+}
+
+func cloneDocsLintFlags(flags *LintFlags) *LintFlags {
+	if flags == nil {
+		return &LintFlags{}
+	}
+	cloned := *flags
+	return &cloned
+}
+
+func loadDocsDiagnosticsRuleset(flags *LintFlags, rulesetPath string) (*rulesets.RuleSet, error) {
+	loadFlags := cloneDocsLintFlags(flags)
+	loadFlags.RulesetFlag = rulesetPath
+	return LoadRulesetWithConfig(loadFlags, slog.Default())
 }
 
 func (d *docsDiagnosticsContext) lintSpec(specBytes []byte, specPath string) ([]*doctorV3.RuleFunctionResult, error) {
@@ -128,17 +197,54 @@ func (d *docsDiagnosticsContext) lintSpec(specBytes []byte, specPath string) ([]
 }
 
 func (d *docsDiagnosticsContext) ruleSetForSpec(specBytes []byte) (*rulesets.RuleSet, error) {
-	if d == nil || d.flags == nil || d.flags.RulesetFlag != "" {
-		if d == nil {
-			return nil, nil
-		}
-		return d.selectedRuleset, nil
+	if d == nil {
+		return nil, nil
 	}
-	selectedRuleset, _, err := LoadRulesetWithConfigForSpec(d.flags, slog.Default(), specBytes)
+	identity, err := press.DetectSpecIdentity(specBytes)
 	if err != nil {
-		return nil, fmt.Errorf("select diagnostics ruleset: %w", err)
+		return nil, fmt.Errorf("detect diagnostics spec family: %w", err)
 	}
-	return selectedRuleset, nil
+	switch identity.Kind {
+	case press.SpecKindOpenAPI:
+		if d.openAPIRuleset != nil {
+			return d.openAPIRuleset, nil
+		}
+	case press.SpecKindAsyncAPI:
+		if d.asyncAPIRuleset != nil {
+			return d.asyncAPIRuleset, nil
+		}
+	default:
+		return nil, fmt.Errorf("detect diagnostics spec family: unsupported specification kind %q", identity.Kind)
+	}
+	if d.legacyRuleset != nil {
+		return d.legacyRuleset, nil
+	}
+	return buildDocsDefaultRuleset(identity.Kind, d.flags), nil
+}
+
+func buildDocsDefaultRuleset(kind press.SpecKind, flags *LintFlags) *rulesets.RuleSet {
+	defaultRuleSets := rulesets.BuildDefaultRuleSetsWithLogger(slog.Default())
+	hardMode := flags != nil && flags.HardModeFlag
+	var selectedRuleset *rulesets.RuleSet
+	switch kind {
+	case press.SpecKindAsyncAPI:
+		if hardMode {
+			selectedRuleset = defaultRuleSets.GenerateAsyncAPIDefaultRuleSet()
+		} else {
+			selectedRuleset = defaultRuleSets.GenerateAsyncAPIRecommendedRuleSet()
+		}
+	default:
+		if hardMode {
+			selectedRuleset = defaultRuleSets.GenerateOpenAPIDefaultRuleSet()
+			MergeOWASPRulesToRuleSet(selectedRuleset, true)
+		} else {
+			selectedRuleset = defaultRuleSets.GenerateOpenAPIRecommendedRuleSet()
+		}
+	}
+	if flags != nil && flags.TurboMode {
+		rulesets.FilterRulesForTurbo(selectedRuleset)
+	}
+	return selectedRuleset
 }
 
 func (d *docsDiagnosticsContext) lintCatalog(catalog *ppmodel.CatalogSite, report docsDiagnosticsProgressFunc) (map[string][]*doctorV3.RuleFunctionResult, error) {
@@ -258,14 +364,18 @@ func resolveDocsLintBase(specPath string, flags *LintFlags) (string, error) {
 	return ResolveBasePathForFile(specPath, "")
 }
 
-func docsDiagnosticsFingerprint(enabled bool, flags *LintFlags, selectedRS *rulesets.RuleSet) string {
+func docsDiagnosticsFingerprint(enabled bool, flags *LintFlags, selectedRS *rulesets.RuleSet, family ...docsFamilyRulesets) string {
 	payload := map[string]any{
 		"diagnosticsEnabled": enabled,
 		"vacuumVersion":      GetVersion(),
 		"lintFlags":          docsFingerprintLintFlags(flags),
 	}
 	if enabled {
-		payload["ruleset"] = docsCanonicalRuleSet(selectedRS)
+		payload["legacyRuleset"] = docsRulesetFingerprintIdentity(docsRulesetPath(flags), selectedRS)
+		if len(family) > 0 {
+			payload["openapiRuleset"] = docsRulesetFingerprintIdentity(family[0].openAPIPath, family[0].openAPI)
+			payload["asyncapiRuleset"] = docsRulesetFingerprintIdentity(family[0].asyncAPIPath, family[0].asyncAPI)
+		}
 		if flags != nil {
 			payload["ignoreFile"] = docsPathFingerprint(flags.IgnoreFile)
 			payload["functions"] = docsPathFingerprint(flags.FunctionsFlag)
@@ -273,6 +383,20 @@ func docsDiagnosticsFingerprint(enabled bool, flags *LintFlags, selectedRS *rule
 	}
 	encoded, _ := json.Marshal(payload)
 	return fmt.Sprintf("%016x", xxhash.Sum64(encoded))
+}
+
+func docsRulesetPath(flags *LintFlags) string {
+	if flags == nil {
+		return ""
+	}
+	return flags.RulesetFlag
+}
+
+func docsRulesetFingerprintIdentity(rulesetPath string, selectedRS *rulesets.RuleSet) map[string]any {
+	return map[string]any{
+		"source":  docsPathFingerprint(rulesetPath),
+		"ruleset": docsCanonicalRuleSet(selectedRS),
+	}
 }
 
 func docsFingerprintLintFlags(flags *LintFlags) map[string]any {

--- a/cmd/docs_family_ruleset_test.go
+++ b/cmd/docs_family_ruleset_test.go
@@ -1,0 +1,416 @@
+// Copyright 2025 Dave Shanley / Quobix / Princess Beef Heavy Industries, LLC
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/daveshanley/vacuum/rulesets"
+	"github.com/daveshanley/vacuum/utils"
+	press "github.com/pb33f/doctor/printingpress"
+	ppconfig "github.com/pb33f/doctor/printingpress/config"
+	"github.com/pb33f/testify/assert"
+	"github.com/pb33f/testify/require"
+)
+
+func TestDocsFamilyRulesetFlags(t *testing.T) {
+	cmd := GetDocsCommand()
+
+	for _, name := range []string{"openapi-ruleset", "asyncapi-ruleset"} {
+		flag := cmd.Flags().Lookup(name)
+		require.NotNil(t, flag)
+		assert.Contains(t, flag.Usage, "diagnostics")
+	}
+}
+
+func TestDocsNoDiagnosticsDoesNotLoadConfiguredFamilyRulesets(t *testing.T) {
+	for _, input := range []string{"single", "aggregate"} {
+		t.Run(input, func(t *testing.T) {
+			root := t.TempDir()
+			specPath := filepath.Join(root, "openapi.yaml")
+			writeTestFile(t, specPath, docsDiagnosticsSpec("Disabled Diagnostics"))
+			docsInput := specPath
+			if input == "aggregate" {
+				docsInput = root
+			}
+
+			cmd := GetDocsCommand()
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.Flags().String("ruleset", "", "")
+			cmd.SetArgs([]string{
+				docsInput,
+				"--output", filepath.Join(t.TempDir(), "docs"),
+				"--no-diagnostics",
+				"--no-llm",
+				"--no-json",
+				"--no-logo",
+				"--openapi-ruleset", filepath.Join(root, "missing-openapi.yaml"),
+				"--asyncapi-ruleset", filepath.Join(root, "missing-asyncapi.yaml"),
+				"--ruleset", filepath.Join(root, "missing-legacy.yaml"),
+			})
+
+			require.NoError(t, cmd.Execute())
+		})
+	}
+}
+
+func TestRunDocsSingleHonorsFamilyRulesets(t *testing.T) {
+	tests := []struct {
+		name          string
+		specName      string
+		spec          string
+		configureOpts func(*docsOptions, string)
+		writeRuleset  func(*testing.T, string, string, string) string
+		ruleID        string
+	}{
+		{
+			name:     "OpenAPI",
+			specName: "openapi.yaml",
+			spec:     docsDiagnosticsSpec("Single HTTP API"),
+			configureOpts: func(opts *docsOptions, path string) {
+				opts.openAPIRuleset = path
+			},
+			writeRuleset: writeDocsNamedRuleset,
+			ruleID:       "single-openapi-family-rule",
+		},
+		{
+			name:     "AsyncAPI",
+			specName: "asyncapi.yaml",
+			spec:     cmdAsyncAPI31Fixture,
+			configureOpts: func(opts *docsOptions, path string) {
+				opts.asyncAPIRuleset = path
+			},
+			writeRuleset: writeDocsNamedAsyncAPIRuleset,
+			ruleID:       "single-asyncapi-family-rule",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			specPath := filepath.Join(root, tt.specName)
+			writeTestFile(t, specPath, tt.spec)
+			rulesetPath := tt.writeRuleset(t, root, "family-ruleset.yaml", tt.ruleID)
+			opts := &docsOptions{
+				outputDir: filepath.Join(t.TempDir(), "docs"),
+				noLLM:     true,
+				noJSON:    true,
+				noLogo:    true,
+			}
+			tt.configureOpts(opts, rulesetPath)
+			cmd := GetDocsCommand()
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			require.NoError(t, runDocs(cmd, specPath, opts))
+			assert.Contains(t, readTestFile(t, filepath.Join(opts.outputDir, "data", "pages", "diagnostics.js")), tt.ruleID)
+		})
+	}
+}
+
+func TestDocsDiagnosticsFamilyRulesetPrecedence(t *testing.T) {
+	root := t.TempDir()
+	legacyPath := writeDocsNamedRuleset(t, root, "legacy.yaml", "legacy-rule")
+	openAPIPath := writeDocsNamedRuleset(t, root, "openapi.yaml", "openapi-rule")
+	asyncAPIPath := writeDocsNamedRuleset(t, root, "asyncapi.yaml", "asyncapi-rule")
+	flags := docsTestLintFlags(legacyPath)
+	original := *flags
+
+	ctx := newDocsTestDiagnosticsContext(t, flags, docsFamilyRulesetPaths{
+		openAPI:  openAPIPath,
+		asyncAPI: asyncAPIPath,
+	})
+
+	tests := []struct {
+		name     string
+		spec     string
+		expected string
+	}{
+		{name: "OpenAPI family override", spec: docsDiagnosticsSpec("HTTP API"), expected: "openapi-rule"},
+		{name: "AsyncAPI family override", spec: cmdAsyncAPI31Fixture, expected: "asyncapi-rule"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ruleSet, err := ctx.ruleSetForSpec([]byte(tt.spec))
+			require.NoError(t, err)
+			assert.Contains(t, ruleSet.Rules, tt.expected)
+			assert.NotContains(t, ruleSet.Rules, "legacy-rule")
+		})
+	}
+
+	assert.Equal(t, original, *flags, "loading docs rulesets must not mutate caller lint flags")
+}
+
+func TestDocsDiagnosticsPartialFamilyOverridesFallBack(t *testing.T) {
+	tests := []struct {
+		name             string
+		legacy           bool
+		configuredFamily string
+		spec             string
+		expectedRule     string
+		unexpectedRule   string
+	}{
+		{name: "OpenAPI override and AsyncAPI legacy fallback", legacy: true, configuredFamily: "openapi", spec: cmdAsyncAPI31Fixture, expectedRule: "legacy-rule", unexpectedRule: "openapi-rule"},
+		{name: "AsyncAPI override and OpenAPI legacy fallback", legacy: true, configuredFamily: "asyncapi", spec: docsDiagnosticsSpec("HTTP API"), expectedRule: "legacy-rule", unexpectedRule: "asyncapi-rule"},
+		{name: "OpenAPI override and AsyncAPI built-in fallback", configuredFamily: "openapi", spec: cmdAsyncAPI31Fixture, expectedRule: rulesets.AsyncAPI3DocumentResolved, unexpectedRule: "openapi-rule"},
+		{name: "AsyncAPI override and OpenAPI built-in fallback", configuredFamily: "asyncapi", spec: docsDiagnosticsSpec("HTTP API"), expectedRule: rulesets.OperationSuccessResponse, unexpectedRule: "asyncapi-rule"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			legacyPath := ""
+			if tt.legacy {
+				legacyPath = writeDocsNamedRuleset(t, root, "legacy.yaml", "legacy-rule")
+			}
+			paths := docsFamilyRulesetPaths{}
+			switch tt.configuredFamily {
+			case "openapi":
+				paths.openAPI = writeDocsNamedRuleset(t, root, "openapi.yaml", "openapi-rule")
+			case "asyncapi":
+				paths.asyncAPI = writeDocsNamedRuleset(t, root, "asyncapi.yaml", "asyncapi-rule")
+			}
+			ctx := newDocsTestDiagnosticsContext(t, docsTestLintFlags(legacyPath), paths)
+
+			ruleSet, err := ctx.ruleSetForSpec([]byte(tt.spec))
+			require.NoError(t, err)
+			assert.Contains(t, ruleSet.Rules, tt.expectedRule)
+			assert.NotContains(t, ruleSet.Rules, tt.unexpectedRule)
+		})
+	}
+}
+
+func TestDocsDiagnosticsConfiguredRulesetsLoadOnce(t *testing.T) {
+	root := t.TempDir()
+	openAPIPath := writeDocsNamedRuleset(t, root, "openapi.yaml", "openapi-rule")
+	asyncAPIPath := writeDocsNamedRuleset(t, root, "asyncapi.yaml", "asyncapi-rule")
+	ctx := newDocsTestDiagnosticsContext(t, docsTestLintFlags(""), docsFamilyRulesetPaths{
+		openAPI:  openAPIPath,
+		asyncAPI: asyncAPIPath,
+	})
+	require.NoError(t, os.Remove(openAPIPath))
+	require.NoError(t, os.Remove(asyncAPIPath))
+
+	for i := 0; i < 2; i++ {
+		openAPIRules, err := ctx.ruleSetForSpec([]byte(docsDiagnosticsSpec("HTTP API")))
+		require.NoError(t, err)
+		assert.Contains(t, openAPIRules.Rules, "openapi-rule")
+
+		asyncAPIRules, err := ctx.ruleSetForSpec([]byte(cmdAsyncAPI31Fixture))
+		require.NoError(t, err)
+		assert.Contains(t, asyncAPIRules.Rules, "asyncapi-rule")
+	}
+}
+
+func TestDocsDiagnosticsFamilyRulesetLoadErrorsIdentifyFamily(t *testing.T) {
+	for _, family := range []string{"OpenAPI", "AsyncAPI"} {
+		t.Run(family, func(t *testing.T) {
+			paths := docsFamilyRulesetPaths{}
+			if family == "OpenAPI" {
+				paths.openAPI = filepath.Join(t.TempDir(), "missing.yaml")
+			} else {
+				paths.asyncAPI = filepath.Join(t.TempDir(), "missing.yaml")
+			}
+
+			_, err := newDocsDiagnosticsContext(docsTestLintFlags(""), utils.HTTPClientConfig{}, nil, true, paths)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, family+" diagnostics ruleset")
+		})
+	}
+}
+
+func TestDocsDiagnosticsRejectsUnknownAndUnsupportedSpecFamilies(t *testing.T) {
+	ctx := newDocsTestDiagnosticsContext(t, docsTestLintFlags(""), docsFamilyRulesetPaths{})
+	for _, tt := range []struct {
+		name string
+		spec string
+	}{
+		{name: "unknown", spec: "info:\n  title: not a contract\n"},
+		{name: "malformed", spec: `{"info": `},
+		{name: "unsupported AsyncAPI", spec: "asyncapi: 2.6.0\ninfo:\n  title: legacy\n  version: 1.0.0\nchannels: {}\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ctx.ruleSetForSpec([]byte(tt.spec))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "detect diagnostics spec family")
+		})
+	}
+}
+
+func TestDocsDiagnosticsFingerprintIncludesAllRulesetIdentities(t *testing.T) {
+	root := t.TempDir()
+	legacyPath := writeDocsNamedRuleset(t, root, "legacy.yaml", "legacy-rule")
+	openAPIPath := writeDocsNamedRuleset(t, root, "openapi.yaml", "openapi-rule")
+	asyncAPIPath := writeDocsNamedRuleset(t, root, "asyncapi.yaml", "asyncapi-rule")
+	flags := docsTestLintFlags(legacyPath)
+	ctx := newDocsTestDiagnosticsContext(t, flags, docsFamilyRulesetPaths{openAPI: openAPIPath, asyncAPI: asyncAPIPath})
+	baseline := ctx.fingerprint
+
+	for i := 0; i < 20; i++ {
+		assert.Equal(t, baseline, docsDiagnosticsFingerprint(true, flags, ctx.legacyRuleset, docsFamilyRulesets{
+			openAPIPath: openAPIPath, openAPI: ctx.openAPIRuleset,
+			asyncAPIPath: asyncAPIPath, asyncAPI: ctx.asyncAPIRuleset,
+		}))
+	}
+
+	for _, tc := range []struct {
+		name string
+		path *string
+		rule string
+	}{
+		{name: "legacy content", path: &legacyPath, rule: "legacy-changed"},
+		{name: "OpenAPI content", path: &openAPIPath, rule: "openapi-changed"},
+		{name: "AsyncAPI content", path: &asyncAPIPath, rule: "asyncapi-changed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			writeTestFile(t, legacyPath, docsNamedRuleset("legacy-rule"))
+			writeTestFile(t, openAPIPath, docsNamedRuleset("openapi-rule"))
+			writeTestFile(t, asyncAPIPath, docsNamedRuleset("asyncapi-rule"))
+			writeTestFile(t, *tc.path, docsNamedRuleset(tc.rule))
+			changed := newDocsTestDiagnosticsContext(t, docsTestLintFlags(legacyPath), docsFamilyRulesetPaths{openAPI: openAPIPath, asyncAPI: asyncAPIPath})
+			assert.NotEqual(t, baseline, changed.fingerprint)
+		})
+	}
+
+	writeTestFile(t, legacyPath, docsNamedRuleset("legacy-rule"))
+	writeTestFile(t, openAPIPath, docsNamedRuleset("openapi-rule"))
+	writeTestFile(t, asyncAPIPath, docsNamedRuleset("asyncapi-rule"))
+	for _, family := range []string{"legacy", "OpenAPI", "AsyncAPI"} {
+		t.Run(family+" path", func(t *testing.T) {
+			otherRoot := t.TempDir()
+			otherLegacyPath := legacyPath
+			otherOpenAPIPath := openAPIPath
+			otherAsyncAPIPath := asyncAPIPath
+			switch family {
+			case "legacy":
+				otherLegacyPath = writeDocsNamedRuleset(t, otherRoot, "legacy.yaml", "legacy-rule")
+			case "OpenAPI":
+				otherOpenAPIPath = writeDocsNamedRuleset(t, otherRoot, "openapi.yaml", "openapi-rule")
+			case "AsyncAPI":
+				otherAsyncAPIPath = writeDocsNamedRuleset(t, otherRoot, "asyncapi.yaml", "asyncapi-rule")
+			}
+			pathChanged := newDocsTestDiagnosticsContext(t, docsTestLintFlags(otherLegacyPath), docsFamilyRulesetPaths{openAPI: otherOpenAPIPath, asyncAPI: otherAsyncAPIPath})
+			assert.NotEqual(t, baseline, pathChanged.fingerprint)
+		})
+	}
+}
+
+func TestDocsDiagnosticsFingerprintIsStableAcrossRuleMapOrder(t *testing.T) {
+	first := docsFingerprintRuleSet("alpha", "first")
+	first.Rules["beta"] = docsFingerprintRuleSet("beta", "second").Rules["beta"]
+	second := docsFingerprintRuleSet("beta", "second")
+	second.Rules["alpha"] = docsFingerprintRuleSet("alpha", "first").Rules["alpha"]
+	flags := docsTestLintFlags("")
+
+	assert.Equal(t,
+		docsDiagnosticsFingerprint(true, flags, nil, docsFamilyRulesets{openAPI: first}),
+		docsDiagnosticsFingerprint(true, flags, nil, docsFamilyRulesets{openAPI: second}),
+	)
+}
+
+func TestBuildDocsAggregateConfigPassesThroughGroupingWithoutAliasing(t *testing.T) {
+	fileConfig := &ppconfig.File{Grouping: ppconfig.GroupingConfig{
+		ServiceIdentity: ppconfig.ServiceIdentityConfig{
+			MetadataPointers:           []string{"/info/x-owner/service"},
+			StripPrefixes:              []string{"platform-"},
+			StripSuffixes:              []string{"-api"},
+			PreferOpenAPISlug:          true,
+			MetadataOptionalForOpenAPI: true,
+		},
+		ContractRoles: []ppconfig.ContractRoleRule{
+			{Pattern: "**/openapi.yaml", Role: "http-api", ContractID: "http", Default: true},
+			{Pattern: "**/asyncapi.yaml", Role: "published-event", ContractID: "events", Default: false},
+		},
+	}}
+
+	cfg := buildDocsAggregateConfig("/apis", "/output", "hosted", &docsOptions{}, fileConfig)
+
+	assert.Equal(t, press.AggregateServiceIdentityConfig{
+		MetadataPointers:           []string{"/info/x-owner/service"},
+		StripPrefixes:              []string{"platform-"},
+		StripSuffixes:              []string{"-api"},
+		PreferOpenAPISlug:          true,
+		MetadataOptionalForOpenAPI: true,
+	}, cfg.ServiceIdentity)
+	assert.Equal(t, []press.AggregateContractRoleRule{
+		{Pattern: "**/openapi.yaml", Role: "http-api", ContractID: "http", Default: true},
+		{Pattern: "**/asyncapi.yaml", Role: "published-event", ContractID: "events", Default: false},
+	}, cfg.ContractRoles)
+
+	cfg.ServiceIdentity.MetadataPointers[0] = "/changed"
+	cfg.ServiceIdentity.StripPrefixes[0] = "changed-"
+	cfg.ServiceIdentity.StripSuffixes[0] = "-changed"
+	cfg.ServiceIdentity.MetadataOptionalForOpenAPI = false
+	cfg.ContractRoles[0].Pattern = "changed"
+	assert.Equal(t, "/info/x-owner/service", fileConfig.Grouping.ServiceIdentity.MetadataPointers[0])
+	assert.Equal(t, "platform-", fileConfig.Grouping.ServiceIdentity.StripPrefixes[0])
+	assert.Equal(t, "-api", fileConfig.Grouping.ServiceIdentity.StripSuffixes[0])
+	assert.True(t, fileConfig.Grouping.ServiceIdentity.MetadataOptionalForOpenAPI)
+	assert.Equal(t, "**/openapi.yaml", fileConfig.Grouping.ContractRoles[0].Pattern)
+}
+
+func newDocsTestDiagnosticsContext(t *testing.T, flags *LintFlags, paths docsFamilyRulesetPaths) *docsDiagnosticsContext {
+	t.Helper()
+	ctx, err := newDocsDiagnosticsContext(flags, utils.HTTPClientConfig{}, nil, true, paths)
+	require.NoError(t, err)
+	return ctx
+}
+
+func docsTestLintFlags(legacyPath string) *LintFlags {
+	return &LintFlags{
+		RulesetFlag:       legacyPath,
+		RemoteFlag:        true,
+		TimeoutFlag:       5,
+		LookupTimeoutFlag: 500,
+		SilentFlag:        true,
+		NoStyleFlag:       true,
+		PipelineOutput:    true,
+	}
+}
+
+func writeDocsNamedRuleset(t *testing.T, root, name, ruleID string) string {
+	t.Helper()
+	path := filepath.Join(root, name)
+	writeTestFile(t, path, docsNamedRuleset(ruleID))
+	return path
+}
+
+func writeDocsNamedAsyncAPIRuleset(t *testing.T, root, name, ruleID string) string {
+	t.Helper()
+	path := filepath.Join(root, name)
+	writeTestFile(t, path, `extends: [[vacuum:asyncapi, off]]
+rules:
+  `+ruleID+`:
+    description: Family marker
+    severity: warn
+    formats: [asyncapi3]
+    given: $.info
+    then:
+      field: title
+      function: pattern
+      functionOptions:
+        match: this-title-never-matches
+`)
+	return path
+}
+
+func docsNamedRuleset(ruleID string) string {
+	return `extends: [[vacuum:oas, off]]
+rules:
+  ` + ruleID + `:
+    description: Family marker
+    severity: warn
+    given: $.info
+    then:
+      field: title
+      function: pattern
+      functionOptions:
+        match: this-title-never-matches
+`
+}

--- a/cmd/docs_family_ruleset_test.go
+++ b/cmd/docs_family_ruleset_test.go
@@ -207,6 +207,23 @@ func TestDocsDiagnosticsConfiguredRulesetsLoadOnce(t *testing.T) {
 	}
 }
 
+func TestDocsDiagnosticsBuiltInFamilyRulesetsLoadOnce(t *testing.T) {
+	ctx := newDocsTestDiagnosticsContext(t, docsTestLintFlags(""), docsFamilyRulesetPaths{})
+
+	firstOpenAPI, err := ctx.ruleSetForSpec([]byte(docsDiagnosticsSpec("HTTP API")))
+	require.NoError(t, err)
+	secondOpenAPI, err := ctx.ruleSetForSpec([]byte(docsDiagnosticsSpec("HTTP API")))
+	require.NoError(t, err)
+	firstAsyncAPI, err := ctx.ruleSetForSpec([]byte(cmdAsyncAPI31Fixture))
+	require.NoError(t, err)
+	secondAsyncAPI, err := ctx.ruleSetForSpec([]byte(cmdAsyncAPI31Fixture))
+	require.NoError(t, err)
+
+	assert.Same(t, firstOpenAPI, secondOpenAPI)
+	assert.Same(t, firstAsyncAPI, secondAsyncAPI)
+	assert.NotSame(t, firstOpenAPI, firstAsyncAPI)
+}
+
 func TestDocsDiagnosticsFamilyRulesetLoadErrorsIdentifyFamily(t *testing.T) {
 	for _, family := range []string{"OpenAPI", "AsyncAPI"} {
 		t.Run(family, func(t *testing.T) {
@@ -256,7 +273,7 @@ func TestDocsDiagnosticsFingerprintIncludesAllRulesetIdentities(t *testing.T) {
 		assert.Equal(t, baseline, docsDiagnosticsFingerprint(true, flags, ctx.legacyRuleset, docsFamilyRulesets{
 			openAPIPath: openAPIPath, openAPI: ctx.openAPIRuleset,
 			asyncAPIPath: asyncAPIPath, asyncAPI: ctx.asyncAPIRuleset,
-		}))
+		}, ctx.fallbackRulesets))
 	}
 
 	for _, tc := range []struct {
@@ -312,6 +329,20 @@ func TestDocsDiagnosticsFingerprintIsStableAcrossRuleMapOrder(t *testing.T) {
 		docsDiagnosticsFingerprint(true, flags, nil, docsFamilyRulesets{openAPI: first}),
 		docsDiagnosticsFingerprint(true, flags, nil, docsFamilyRulesets{openAPI: second}),
 	)
+}
+
+func TestDocsDiagnosticsFingerprintIncludesBuiltInFamilyRulesets(t *testing.T) {
+	flags := docsTestLintFlags("")
+	fingerprint := func(openAPIMessage, asyncAPIMessage string) string {
+		return docsDiagnosticsFingerprint(true, flags, nil, docsFamilyRulesets{}, docsFamilyRulesets{
+			openAPI:  docsFingerprintRuleSet("openapi-default", openAPIMessage),
+			asyncAPI: docsFingerprintRuleSet("asyncapi-default", asyncAPIMessage),
+		})
+	}
+	baseline := fingerprint("openapi baseline", "asyncapi baseline")
+
+	assert.NotEqual(t, baseline, fingerprint("openapi changed", "asyncapi baseline"))
+	assert.NotEqual(t, baseline, fingerprint("openapi baseline", "asyncapi changed"))
 }
 
 func TestBuildDocsAggregateConfigPassesThroughGroupingWithoutAliasing(t *testing.T) {

--- a/cmd/docs_press.go
+++ b/cmd/docs_press.go
@@ -497,6 +497,22 @@ func buildDocsAggregateConfig(scanRoot, outputDir, assetMode string, opts *docsO
 	cfg.Include = append([]string(nil), fileConfig.Scan.Include...)
 	cfg.IgnoreRules = append([]string(nil), fileConfig.Scan.IgnoreRules...)
 	cfg.NoiseSegments = append([]string(nil), fileConfig.Grouping.NoiseSegments...)
+	cfg.ServiceIdentity = press.AggregateServiceIdentityConfig{
+		MetadataPointers:           append([]string(nil), fileConfig.Grouping.ServiceIdentity.MetadataPointers...),
+		StripPrefixes:              append([]string(nil), fileConfig.Grouping.ServiceIdentity.StripPrefixes...),
+		StripSuffixes:              append([]string(nil), fileConfig.Grouping.ServiceIdentity.StripSuffixes...),
+		PreferOpenAPISlug:          fileConfig.Grouping.ServiceIdentity.PreferOpenAPISlug,
+		MetadataOptionalForOpenAPI: fileConfig.Grouping.ServiceIdentity.MetadataOptionalForOpenAPI,
+	}
+	cfg.ContractRoles = make([]press.AggregateContractRoleRule, len(fileConfig.Grouping.ContractRoles))
+	for i, role := range fileConfig.Grouping.ContractRoles {
+		cfg.ContractRoles[i] = press.AggregateContractRoleRule{
+			Pattern:    role.Pattern,
+			Role:       role.Role,
+			ContractID: role.ContractID,
+			Default:    role.Default,
+		}
+	}
 	cfg.ServiceOverrides = toDocsAggregateOverrides(fileConfig.Grouping.ServiceOverrides)
 	cfg.DisplayNameOverrides = toDocsAggregateOverrides(fileConfig.Grouping.DisplayNameOverrides)
 	cfg.VersionOverrides = toDocsAggregateOverrides(fileConfig.Grouping.VersionOverrides)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/muesli/termenv v0.16.0
-	github.com/pb33f/doctor v0.0.79
+	github.com/pb33f/doctor v0.0.80
 	github.com/pb33f/jsonpath v0.8.3
 	github.com/pb33f/libasyncapi v0.0.2
 	github.com/pb33f/libopenapi v0.38.7

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/pb33f/doctor v0.0.79 h1:g0Tn6MK3C/rPAIFTfBMBPlhUPv6rsm2gavbDpcEb0GM=
-github.com/pb33f/doctor v0.0.79/go.mod h1:1Det/ZyGtfwUK0P28IjcTmVqsM8xjA6tonRvsbDNVYs=
+github.com/pb33f/doctor v0.0.80 h1:A5QEGWRJ11rS1wp1ypEioXAWQBaMqzmWtQCR61dLXmY=
+github.com/pb33f/doctor v0.0.80/go.mod h1:1Det/ZyGtfwUK0P28IjcTmVqsM8xjA6tonRvsbDNVYs=
 github.com/pb33f/jsonpath v0.8.3 h1:gdOUYn31vic8iRSSR4I2SEv7UQf2WxLeDcUnDPpGZNE=
 github.com/pb33f/jsonpath v0.8.3/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
 github.com/pb33f/libasyncapi v0.0.2 h1:mQn5br4VmDQwnYk8c2s7pVehBVQit1dNxjqoQoy4ZXk=

--- a/motor/rule_applicator.go
+++ b/motor/rule_applicator.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	vacuumUtils "github.com/daveshanley/vacuum/utils"
@@ -107,6 +108,8 @@ type RuleSetExecution struct {
 	SkipCircularCheck bool // Skip circular reference result injection
 	SkipSchemaErrors  bool // Skip schema build error injection
 	SpecFormat        string
+	ruleWaitGroup     sync.WaitGroup
+	activeRuleWorkers atomic.Int64
 }
 
 // RuleSetExecutionResult returns the results of running the ruleset against the supplied spec.
@@ -126,6 +129,10 @@ type RuleSetExecutionResult struct {
 	ownedDocument    libopenapi.Document
 	unresolvedDoc    libopenapi.Document
 	ownedIndex       *index.SpecIndex
+	releaseOnce      sync.Once
+	releaseClearAll  atomic.Bool
+	releaseCleared   atomic.Bool
+	releaseDone      chan struct{}
 }
 
 // HasTruncatedPaths reports whether result-path reconciliation limited resolved aliases.
@@ -294,57 +301,90 @@ func (r *RuleSetExecutionResult) release(clearCaches bool) {
 		return
 	}
 
-	execution := r.RuleSetExecution
-
-	ownedResources := ownedResultResources{
-		resolvedDocument:   r.ownedDocument,
-		unresolvedDocument: r.unresolvedDoc,
-		resolvedIndex:      r.ownedIndex,
-	}
-	ownedResources.release()
-
-	if execution != nil && execution.DrDocument != nil {
-		execution.DrDocument.Release()
-		execution.DrDocument = nil
-	}
-
-	if execution != nil {
-		if execution.IndexUnresolved != nil && execution.CanonicalDocument == execution.IndexUnresolved.GetRootNode() {
-			execution.CanonicalDocument = nil
-		}
-		execution.IndexResolved = nil
-		execution.IndexUnresolved = nil
-	}
-
 	if clearCaches {
+		r.releaseClearAll.Store(true)
+	}
+	startedRelease := false
+	r.releaseOnce.Do(func() {
+		startedRelease = true
+		r.releaseDone = make(chan struct{})
+		execution := r.RuleSetExecution
+		ownedResources := ownedResultResources{
+			resolvedDocument:   r.ownedDocument,
+			unresolvedDocument: r.unresolvedDoc,
+			resolvedIndex:      r.ownedIndex,
+		}
+		r.RuleSetExecution = nil
+		r.Results = nil
+		r.IgnoredResults = nil
+		r.FixedResults = nil
+		r.Index = nil
+		r.SpecInfo = nil
+		r.Errors = nil
+		r.DocumentConfig = nil
+		r.ModifiedSpec = nil
+		r.AsyncAPI = nil
+		r.ownedDocument = nil
+		r.unresolvedDoc = nil
+		r.ownedIndex = nil
+
+		finishRelease := func() {
+			if execution != nil {
+				execution.ruleWaitGroup.Wait()
+			}
+			ownedResources.release()
+
+			if execution != nil && execution.DrDocument != nil {
+				execution.DrDocument.Release()
+				execution.DrDocument = nil
+			}
+
+			if execution != nil {
+				if execution.IndexUnresolved != nil && execution.CanonicalDocument == execution.IndexUnresolved.GetRootNode() {
+					execution.CanonicalDocument = nil
+				}
+				execution.IndexResolved = nil
+				execution.IndexUnresolved = nil
+			}
+
+			close(r.releaseDone)
+			r.clearCachesIfRequested()
+		}
+
+		if execution != nil && execution.activeRuleWorkers.Load() > 0 {
+			go finishRelease()
+			return
+		}
+		finishRelease()
+	})
+
+	if !startedRelease && clearCaches {
+		select {
+		case <-r.releaseDone:
+			r.clearCachesIfRequested()
+		default:
+		}
+	}
+}
+
+func (r *RuleSetExecutionResult) clearCachesIfRequested() {
+	if r.releaseClearAll.Load() && r.releaseCleared.CompareAndSwap(false, true) {
 		libopenapi.ClearAllCaches()
 	}
-
-	r.RuleSetExecution = nil
-	r.Results = nil
-	r.IgnoredResults = nil
-	r.FixedResults = nil
-	r.Index = nil
-	r.SpecInfo = nil
-	r.Errors = nil
-	r.DocumentConfig = nil
-	r.ModifiedSpec = nil
-	r.AsyncAPI = nil
-	r.ownedDocument = nil
-	r.unresolvedDoc = nil
-	r.ownedIndex = nil
 }
 
 // ReleaseOwnedResources frees result-owned documents, indexes and other
 // retained execution resources without resetting libopenapi's process-wide
-// caches. Caller-supplied documents are never released by vacuum.
+// caches. Caller-supplied documents are never released by vacuum. If a timed-out
+// rule is still running, cleanup continues in the background after it exits.
 func (r *RuleSetExecutionResult) ReleaseOwnedResources() {
 	r.release(false)
 }
 
 // Release frees memory-heavy resources retained by the result once the caller is
 // finished inspecting it. This includes vacuum-owned documents, the doctor
-// document, indexes, and libopenapi's process-wide caches.
+// document, indexes, and libopenapi's process-wide caches. If a timed-out rule
+// is still running, cleanup continues in the background after it exits.
 //
 // The cache reset is global, not scoped to this result. Calling Release can
 // affect other concurrent linting or document-processing routines running in the
@@ -426,8 +466,6 @@ func ApplyRulesToRuleSetWithOptions(execution *RuleSetExecution, executionOption
 	var ruleResults []model.RuleFunctionResult
 	var ignoredResults []model.RuleFunctionResult
 	var fixedResults []model.RuleFunctionResult
-	// (ruleWaitGroup removed — synchronization uses done channel below)
-
 	if asyncResult, handled := ApplyAsyncAPIRulesToRuleSet(execution, &opts, builtinFunctions); handled {
 		return asyncResult
 	}
@@ -582,7 +620,22 @@ func ApplyRulesToRuleSetWithOptions(execution *RuleSetExecution, executionOption
 	docResolved := execution.Document
 	var docUnresolved libopenapi.Document
 	ownedResources := &ownedResultResources{}
-	defer ownedResources.release()
+	resourcesTransferred := false
+	defer func() {
+		if !resourcesTransferred {
+			cleanup := func() {
+				execution.ruleWaitGroup.Wait()
+				ownedResources.release()
+			}
+			if execution.activeRuleWorkers.Load() > 0 {
+				go cleanup()
+				return
+			}
+			cleanup()
+			return
+		}
+		ownedResources.release()
+	}()
 
 	// If no docResolved is supplied (default) then create a new one.
 	// otherwise update the configuration with the supplied document.
@@ -1321,6 +1374,7 @@ func ApplyRulesToRuleSetWithOptions(execution *RuleSetExecution, executionOption
 		ModifiedSpec:     modifiedSpec,
 	}
 	ownedResources.transfer(result)
+	resourcesTransferred = true
 	return result
 }
 

--- a/motor/rule_runner.go
+++ b/motor/rule_runner.go
@@ -124,7 +124,15 @@ func executeRuleContext(
 	localCtx.fixedResults = &localFixed
 	localCtx.errors = &localErrs
 
-	go runRule(localCtx, doneChan)
+	execution.ruleWaitGroup.Add(1)
+	execution.activeRuleWorkers.Add(1)
+	go func() {
+		defer func() {
+			execution.ruleWaitGroup.Done()
+			execution.activeRuleWorkers.Add(-1)
+		}()
+		runRule(localCtx, doneChan)
+	}()
 	select {
 	case <-timeoutCtx.Done():
 		if ctx.logger != nil {

--- a/motor/rule_timeout_test.go
+++ b/motor/rule_timeout_test.go
@@ -3,6 +3,7 @@ package motor
 import (
 	"runtime"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -40,6 +41,25 @@ type concurrencyTrackingRule struct {
 	active    atomic.Int32
 	maxActive atomic.Int32
 	sleep     time.Duration
+}
+
+type channelBlockingRule struct {
+	started chan struct{}
+	unblock <-chan struct{}
+}
+
+func (c *channelBlockingRule) GetSchema() model.RuleFunctionSchema {
+	return model.RuleFunctionSchema{Name: "channelBlocking"}
+}
+
+func (c *channelBlockingRule) GetCategory() string {
+	return model.CategoryValidation
+}
+
+func (c *channelBlockingRule) RunRule(_ []*yaml.Node, _ model.RuleFunctionContext) []model.RuleFunctionResult {
+	close(c.started)
+	<-c.unblock
+	return nil
 }
 
 func (c *concurrencyTrackingRule) GetSchema() model.RuleFunctionSchema {
@@ -106,6 +126,108 @@ paths: {}`
 
 	time.Sleep(150 * time.Millisecond)
 	assert.Len(t, results.Results, 0)
+}
+
+func TestRuleTimeout_ReleaseOwnedResourcesReturnsPromptlyForTimedOutRule(t *testing.T) {
+	yml := `openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}`
+
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	var unblockOnce sync.Once
+	unblockRule := func() {
+		unblockOnce.Do(func() { close(unblock) })
+	}
+	defer unblockRule()
+
+	rule := &channelBlockingRule{started: started, unblock: unblock}
+	execution := &RuleSetExecution{
+		RuleSet: &rulesets.RuleSet{Rules: map[string]*model.Rule{
+			"channel-blocking": {
+				Id:           "channel-blocking",
+				Given:        "$",
+				RuleCategory: model.RuleCategories[model.CategoryValidation],
+				Type:         rulesets.Validation,
+				Severity:     model.SeverityError,
+				Then: model.RuleAction{
+					Function: "channelBlocking",
+				},
+			},
+		}},
+		Spec:    []byte(yml),
+		Timeout: 20 * time.Millisecond,
+		CustomFunctions: map[string]model.RuleFunction{
+			"channelBlocking": rule,
+		},
+		SilenceLogs: true,
+	}
+
+	applyDone := make(chan *RuleSetExecutionResult, 1)
+	go func() {
+		applyDone <- ApplyRulesToRuleSet(execution)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("custom rule did not start")
+	}
+
+	var results *RuleSetExecutionResult
+	select {
+	case results = <-applyDone:
+	case <-time.After(time.Second):
+		t.Fatal("ApplyRulesToRuleSet did not return promptly after the rule timeout")
+	}
+	assert.NotNil(t, results)
+
+	assert.NotNil(t, execution.DrDocument)
+	assert.NotNil(t, execution.IndexResolved)
+	assert.NotNil(t, execution.IndexUnresolved)
+
+	releaseReturned := make(chan struct{})
+	go func() {
+		results.ReleaseOwnedResources()
+		close(releaseReturned)
+	}()
+
+	releaseWasPrompt := false
+	select {
+	case <-releaseReturned:
+		releaseWasPrompt = true
+	case <-time.After(time.Second):
+	}
+	assert.True(t, releaseWasPrompt, "ReleaseOwnedResources blocked on a timed-out rule")
+	assert.Nil(t, results.RuleSetExecution)
+	cleanupDone := results.releaseDone
+	assert.NotNil(t, cleanupDone)
+	select {
+	case <-cleanupDone:
+		t.Fatal("resources were released while the timed-out rule was still blocked")
+	default:
+	}
+	assert.NotNil(t, execution.DrDocument)
+	assert.NotNil(t, execution.IndexResolved)
+	assert.NotNil(t, execution.IndexUnresolved)
+
+	unblockRule()
+	select {
+	case <-releaseReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReleaseOwnedResources did not return after the rule was unblocked")
+	}
+	select {
+	case <-cleanupDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("deferred resource cleanup did not finish after the rule was unblocked")
+	}
+	assert.Nil(t, execution.DrDocument)
+	assert.Nil(t, execution.IndexResolved)
+	assert.Nil(t, execution.IndexUnresolved)
+	assert.Nil(t, execution.CanonicalDocument)
 }
 
 func TestRuleRunnerConcurrencyIgnoresGOMAXPROCSOne(t *testing.T) {

--- a/parser/json_schema.go
+++ b/parser/json_schema.go
@@ -62,8 +62,6 @@ func ConvertNodeIntoJSONSchema(node *yaml.Node, idx *index.SpecIndex) (*highBase
 }
 
 // Global validator instance and mutex to ensure thread-safe schema validation.
-// The mutex also covers yaml.Node marshaling because the YAML desolver mutates
-// node metadata while rendering; callers may validate the same parsed node concurrently.
 var (
 	globalValidator     schema_validation.SchemaValidator
 	globalValidatorOnce sync.Once
@@ -89,16 +87,20 @@ func ValidateNodeAgainstSchema(ctx *model.RuleFunctionContext, schema *highBase.
 	globalValidatorMu.Lock()
 	defer globalValidatorMu.Unlock()
 
+	// yaml.Marshal's desolver mutates node metadata while rendering. Marshal a
+	// deep clone so validation never changes caller-owned nodes.
+	validationNode := utils.CloneYAMLNode(node)
+
 	// convert node to raw yaml first, then convert to json to be used in schema validation
 	var d []byte
 	var e error
 	if !isArray {
-		d, e = yaml.Marshal(node)
+		d, e = yaml.Marshal(validationNode)
 	} else {
-		if !utils.IsNodeArray(node) {
-			d, e = yaml.Marshal([]*yaml.Node{node})
+		if !utils.IsNodeArray(validationNode) {
+			d, e = yaml.Marshal([]*yaml.Node{validationNode})
 		} else {
-			d, e = yaml.Marshal(node)
+			d, e = yaml.Marshal(validationNode)
 		}
 	}
 	if e != nil {

--- a/parser/json_schema_test.go
+++ b/parser/json_schema_test.go
@@ -1,12 +1,16 @@
 package parser
 
 import (
+	"fmt"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pb33f/jsonpath/pkg/jsonpath"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/pb33f/libopenapi/utils"
 	"github.com/pb33f/testify/assert"
 	"go.yaml.in/yaml/v4"
 )
@@ -160,6 +164,84 @@ name: "John123"  # contains numbers
 			}
 		})
 	}
+}
+
+func TestValidateNodeAgainstSchema_DoesNotMutateInput(t *testing.T) {
+	schema, err := ConvertYAMLIntoJSONSchema(`
+type: object
+properties:
+  name:
+    type: string
+  count:
+    type: integer
+  enabled:
+    type: boolean
+`, nil)
+	assert.NoError(t, err)
+
+	var dataNode yaml.Node
+	err = yaml.Unmarshal([]byte("name: example\ncount: 3\nenabled: true\n"), &dataNode)
+	assert.NoError(t, err)
+	input := dataNode.Content[0]
+	before := utils.CloneYAMLNode(input)
+
+	valid, validationErrs := ValidateNodeAgainstSchema(nil, schema, input, false)
+
+	assert.True(t, valid)
+	assert.Empty(t, validationErrs)
+	assert.Equal(t, before, input)
+}
+
+func TestValidateNodeAgainstSchema_ConcurrentTraversalDoesNotRace(t *testing.T) {
+	schema, err := ConvertYAMLIntoJSONSchema("type: object\n", nil)
+	assert.NoError(t, err)
+
+	var dataYAML strings.Builder
+	for i := 0; i < 1024; i++ {
+		_, _ = fmt.Fprintf(&dataYAML, "field%d: value%d\n", i, i)
+	}
+	var dataNode yaml.Node
+	err = yaml.Unmarshal([]byte(dataYAML.String()), &dataNode)
+	assert.NoError(t, err)
+	input := dataNode.Content[0]
+
+	started := make(chan struct{})
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	var checksum atomic.Int64
+	go func() {
+		defer close(done)
+		checksum.Store(int64(yamlNodeTraversalChecksum(input)))
+		close(started)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				checksum.Store(int64(yamlNodeTraversalChecksum(input)))
+			}
+		}
+	}()
+	<-started
+
+	valid, validationErrs := ValidateNodeAgainstSchema(nil, schema, input, false)
+	close(stop)
+	<-done
+
+	assert.True(t, valid)
+	assert.Empty(t, validationErrs)
+	assert.NotZero(t, checksum.Load())
+}
+
+func yamlNodeTraversalChecksum(node *yaml.Node) int {
+	if node == nil {
+		return 0
+	}
+	checksum := int(node.Kind) + int(node.Style) + len(node.Tag) + len(node.Value) + len(node.Anchor)
+	for _, child := range node.Content {
+		checksum += yamlNodeTraversalChecksum(child)
+	}
+	return checksum
 }
 
 // TestIssue512_NonDeterministicValidation specifically tests the scenarios from issue #512


### PR DESCRIPTION
@daveshanley This is a downstream update associated with the earlier doctor change. https://github.com/pb33f/doctor/pull/116

## Summary

This MR extends `vacuum docs` so OpenAPI and AsyncAPI contracts can be validated according to their specification family while appearing together in a coherent service documentation site.

It:

- Adds separate OpenAPI and AsyncAPI ruleset configuration for documentation diagnostics.
- Selects the appropriate parser and ruleset for each contract instead of treating every discovered specification as OpenAPI.
- Propagates service identity and contract-role configuration into Doctor, allowing HTTP APIs, published events, and consumed events to be grouped and navigated as contracts of the same service.
- Adds coverage for mixed OpenAPI and AsyncAPI catalogs, family-specific diagnostics, and configuration isolation.
- Makes concurrent lint resource cleanup safe when multiple workers share parsed resources.
- Upgrades Doctor to `v0.0.80`, which provides the underlying service and contract navigation support.

The result is a documentation workflow where OpenAPI and AsyncAPI retain their own validation semantics without creating separate or inconsistent browsing experiences.
