### PR TITLE
fix: binary install with pnpm and yarn

### DIFF
--- a/npm-install/postinstall.js
+++ b/npm-install/postinstall.js
@@ -68,7 +68,9 @@ async function install() {
         console.log("Installation successful!");
         return;
     }
-    const packageJson = await fs.readFile("package.json").then(JSON.parse);
+    const packageJson = await fs
+        .readFile(new URL("../package.json", import.meta.url))
+        .then(JSON.parse);
     let version = packageJson.version;
 
     if (typeof version !== "string") {


### PR DESCRIPTION
The postinstall script reads `package.json` from the current directory to get the version. With npm that directory is the package itself, so it works. With pnpm or yarn the current directory is different, so it reads the wrong version, builds a bad download URL, and the binary download fails with a 404.

This reads the package's own `package.json` instead (relative to the script), so it works with every package manager.

To reproduce: `pnpm add @quobix/vacuum` tries to download `v0.0.0` and fails.
